### PR TITLE
fix: define custom font utilities

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -20,6 +21,8 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Cairo', 'system-ui', 'sans-serif'],
+        heading: ['var(--font-heading)'],
+        body: ['var(--font-body)'],
       },
       colors: {
         border: 'hsl(var(--border))',
@@ -158,5 +161,5 @@ export default {
       }
     }
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add custom font-heading and font-body utilities
- import tailwindcss-animate using ES module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Could not resolve "../../config/config" from src/components/auth/AuthContext.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689e3a80ae308330b6ae6f0316725130