### PR TITLE
fix: ensure card hover color and API config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public_html/
-/frontend/src/config/
+/frontend/src/config/*
+!/frontend/src/config/config.js
 /frontend/dev-dist

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,0 +1,7 @@
+const base = import.meta.env.VITE_API_BASE_URL || '';
+
+const API_CONFIG = {
+  baseURL: base.startsWith('http') ? base : `http://${base}`,
+};
+
+export default API_CONFIG;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -20,6 +21,8 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Cairo', 'system-ui', 'sans-serif'],
+        heading: ['var(--font-heading)'],
+        body: ['var(--font-body)'],
       },
       colors: {
         border: 'hsl(var(--border))',
@@ -57,6 +60,7 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))'
         },
+        'card-hover': 'hsl(var(--card-hover))',
         sidebar: {
           DEFAULT: 'hsl(var(--sidebar-background))',
           foreground: 'hsl(var(--sidebar-foreground))',
@@ -158,5 +162,5 @@ export default {
       }
     }
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add explicit `card-hover` color so `hover:bg-card-hover` utilities compile
- provide `src/config/config.js` wired to `VITE_API_BASE_URL`
- track config path in `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3a80ae308330b6ae6f0316725130