### PR TITLE
feat: add persistent sidebar with mini mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public_html/
-/frontend/src/config/
+/frontend/src/config/*
+!/frontend/src/config/nav.tsx
 /frontend/dev-dist

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,7 +12,8 @@ dist
 build
 dist-ssr
 *.local
- /src/config/
+/src/config/*
+!/src/config/nav.tsx
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { NAV_ITEMS } from "@/config/nav";
+import SidebarItem from "./SidebarItem";
+import { useSidebarStore } from "@/store/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+export default function Sidebar({ onLinkClick }: { onLinkClick?: () => void }) {
+  const { isOpen, toggle } = useSidebarStore();
+  const isMobile = useIsMobile();
+  const isMini = !isOpen && !isMobile;
+
+  const mobileCls = isOpen ? "translate-x-0" : "-translate-x-full";
+
+  return (
+    <aside
+      dir="rtl"
+      className={`fixed top-0 bottom-0 z-30 bg-card border-r border-border transition-all duration-300 flex flex-col ${
+        isMobile ? `w-64 ${mobileCls}` : isMini ? "w-16" : "w-64"
+      }`}
+    >
+      <div className="h-16 flex items-center justify-between px-3">
+        {!isMini && <div className="font-semibold truncate">المـدار</div>}
+        <button
+          onClick={toggle}
+          className="p-2 rounded-lg bg-card hover:bg-card-hover transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <span className="sr-only">Toggle sidebar</span>
+          ≡
+        </button>
+      </div>
+
+      <nav className="px-2 pb-4 overflow-y-auto flex-1">
+        {NAV_ITEMS.map((item) => (
+          <SidebarItem key={item.id} item={item} isMini={isMini} onLinkClick={onLinkClick} />
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/src/components/layout/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarItem.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { NavItem } from "@/config/nav";
+import { useSidebarStore } from "@/store/sidebar";
+import Tooltip from "@/components/ui/Tooltip";
+
+type SidebarItemProps = {
+  item: NavItem;
+  isMini: boolean;
+  onLinkClick?: () => void;
+};
+
+export default function SidebarItem({ item, isMini, onLinkClick }: SidebarItemProps) {
+  const { activeSection, setActiveSection } = useSidebarStore();
+  const hasChildren = !!item.children?.length;
+  const opened = activeSection === item.id;
+  const submenuId = `${item.id}-submenu`;
+
+  const toggleSection = () => setActiveSection(opened ? null : item.id);
+
+  const Wrapper = hasChildren ? "button" : NavLink;
+  const wrapperProps = hasChildren
+    ? {
+        onClick: toggleSection,
+        "aria-expanded": opened,
+        "aria-controls": submenuId,
+        className:
+          "w-full flex items-center gap-x-3 p-2 rounded-md text-sm font-medium bg-card hover:bg-card-hover transition-colors focus:outline-none focus:ring-2 focus:ring-ring",
+      }
+    : {
+        to: item.path!,
+        onClick: onLinkClick,
+        className: ({ isActive }: { isActive: boolean }) =>
+          `flex items-center gap-x-3 p-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${
+            isActive ? "bg-card-hover shadow-sm" : "hover:bg-card-hover"
+          }`,
+      };
+
+  const content = (
+    <Wrapper {...wrapperProps}>
+      <span className="shrink-0">{item.icon}</span>
+      {!isMini && <span className="flex-1 text-right">{item.label}</span>}
+      {hasChildren && !isMini && (
+        <ChevronRight className={`w-4 h-4 transition-transform ${opened ? "rotate-90" : ""}`} />
+      )}
+    </Wrapper>
+  );
+
+  return (
+    <div className="relative mb-1">
+      {isMini ? <Tooltip text={item.label}>{content}</Tooltip> : content}
+
+      <AnimatePresence initial={false}>
+        {hasChildren && opened && (
+          isMini ? (
+            <motion.div
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 20 }}
+              className="absolute top-0 right-full me-2 z-40 w-48 overflow-hidden rounded-md border border-border bg-card shadow-md"
+            >
+              {item.children!.map((ch) => (
+                <NavLink
+                  key={ch.id}
+                  to={ch.path}
+                  onClick={onLinkClick}
+                  className={({ isActive }) =>
+                    `flex items-center gap-x-2 p-2 text-sm transition-colors rounded-md ${
+                      isActive ? "bg-card-hover shadow-sm" : "hover:bg-card-hover"
+                    }`
+                  }
+                >
+                  <span className="shrink-0">{ch.icon}</span>
+                  <span className="flex-1 text-right">{ch.label}</span>
+                </NavLink>
+              ))}
+            </motion.div>
+          ) : (
+            <motion.div
+              id={submenuId}
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              className="ms-6 mt-1 overflow-hidden border-r border-border"
+            >
+              {item.children!.map((ch) => (
+                <NavLink
+                  key={ch.id}
+                  to={ch.path}
+                  onClick={onLinkClick}
+                  className={({ isActive }) =>
+                    `flex items-center gap-x-2 px-3 py-2 rounded-md text-sm transition-colors ${
+                      isActive ? "bg-card-hover shadow-sm" : "hover:bg-card-hover"
+                    }`
+                  }
+                >
+                  <span className="shrink-0">{ch.icon}</span>
+                  <span className="text-right">{ch.label}</span>
+                </NavLink>
+              ))}
+            </motion.div>
+          )
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+

--- a/frontend/src/components/layout/Sidebar/index.ts
+++ b/frontend/src/components/layout/Sidebar/index.ts
@@ -1,0 +1,2 @@
+export { default as Sidebar } from "./Sidebar";
+export { default as SidebarItem } from "./SidebarItem";

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+type TooltipProps = {
+  text: string;
+  children: React.ReactNode;
+};
+
+export default function Tooltip({ text, children }: TooltipProps) {
+  return (
+    <div className="relative group">
+      {children}
+      <div className="pointer-events-none absolute top-1/2 -translate-y-1/2 right-full me-2 z-50 hidden whitespace-nowrap rounded-md bg-card px-2 py-1 text-xs text-foreground shadow border border-border group-hover:block">
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/config/nav.tsx
+++ b/frontend/src/config/nav.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import {
+  ContractsIcon,
+  ConsultationsIcon,
+  LawsuitsIcon,
+  DashboardIcon,
+  ArchiveIcon,
+  CourtHouseIcon,
+  LawBookIcon,
+  LegalBriefcaseIcon,
+} from "@/components/ui/Icons";
+import { UsersRound, UserCheck } from "lucide-react";
+
+export type NavChild = {
+  id: string;
+  label: string;
+  path: string;
+  icon?: ReactNode;
+};
+
+export type NavItem = {
+  id: string;
+  label: string;
+  path?: string;
+  icon: ReactNode;
+  children?: NavChild[];
+  permission?: string;
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  { id: "home", label: "الرئيسية", path: "/", icon: <DashboardIcon size={20} /> },
+  { id: "contracts", label: "التعاقدات", path: "/contracts", icon: <ContractsIcon size={20} /> },
+  {
+    id: "fatwa",
+    label: "الرأي والفتوى",
+    icon: <ConsultationsIcon size={20} />,
+    children: [
+      { id: "investigations", label: "التحقيقات", path: "/legal/investigations", icon: <LawsuitsIcon size={16} /> },
+      { id: "legal-advices", label: "المشورة القانونية", path: "/legal/legal-advices", icon: <LawBookIcon size={16} /> },
+      { id: "litigations", label: "التقاضي", path: "/legal/litigations", icon: <CourtHouseIcon size={16} /> },
+    ],
+  },
+  {
+    id: "management",
+    label: "إدارة التطبيق",
+    icon: <LegalBriefcaseIcon size={20} />,
+    children: [{ id: "lists", label: "القوائم", path: "/managment-lists", icon: <LegalBriefcaseIcon size={16} /> }],
+  },
+  {
+    id: "users",
+    label: "إدارة المستخدمين",
+    icon: <UsersRound size={20} />,
+    children: [{ id: "users-list", label: "المستخدمين", path: "/users", icon: <UserCheck size={16} /> }],
+  },
+  { id: "archive", label: "الأرشيف", path: "/archive", icon: <ArchiveIcon size={20} /> },
+];
+

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from "react";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { useSidebarStore } from "@/store/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+type AppLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function AppLayout({ children }: AppLayoutProps) {
+  const { isOpen, setOpen } = useSidebarStore();
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setOpen]);
+
+  return (
+    <div dir="rtl" className="min-h-screen flex bg-background">
+      <Sidebar onLinkClick={() => isMobile && setOpen(false)} />
+      {isMobile && isOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+      <main
+        className={`flex-1 transition-all duration-300 ${
+          isMobile ? "me-0" : isOpen ? "me-64" : "me-16"
+        }`}
+      >
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ import {
   BarChart3,
   Calendar
 } from 'lucide-react';
-import AppLayout from '@/components/layout/AppLayout';
+import AppLayout from '@/layouts/AppLayout';
 import SectionHeader from '@/components/common/SectionHeader';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/frontend/src/store/sidebar.ts
+++ b/frontend/src/store/sidebar.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type SidebarState = {
+  isOpen: boolean;
+  activeSection: string | null;
+  toggle: () => void;
+  setOpen: (val: boolean) => void;
+  setActiveSection: (id: string | null) => void;
+};
+
+export const useSidebarStore = create<SidebarState>()(
+  persist(
+    (set) => ({
+      isOpen: true,
+      activeSection: null,
+      toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+      setOpen: (val) => set({ isOpen: val }),
+      setActiveSection: (id) => set({ activeSection: id }),
+    }),
+    { name: "almadar.sidebar" }
+  )
+);
+


### PR DESCRIPTION
## Summary
- add config-driven navigation schema and items
- implement responsive sidebar with mini mode, tooltips, and persistence
- integrate sidebar into layout and update dashboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e8d454c348330830c9105448fb670