### PR TITLE
fix: show sidebar only for authenticated users

### DIFF
--- a/frontend/src/config/nav.tsx
+++ b/frontend/src/config/nav.tsx
@@ -22,7 +22,7 @@ export type NavItem = {
 };
 
 export const NAV: NavItem[] = [
-  { id: "home", icon: <DashboardIcon size={20} />, path: "/", labelAr: "الرئيسية", labelEn: "Home" },
+  { id: "home", icon: <DashboardIcon size={20} />, path: "/dashboard", labelAr: "الرئيسية", labelEn: "Home" },
   { id: "contracts", icon: <ContractsIcon size={20} />, path: "/contracts", labelAr: "التعاقدات", labelEn: "Contracts" },
   {
     id: "fatwa", icon: <ConsultationsIcon size={20} />, labelAr: "الرأي والفتوى", labelEn: "Advisory",

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -3,13 +3,16 @@ import { Outlet } from "react-router-dom";
 import Sidebar from "@/components/layout/Sidebar/Sidebar";
 import LoadingBar from "@/components/LoadingBar";
 import { useRouteProgress } from "@/hooks/useRouteProgress";
+import { useAuth } from "@/context/AuthContext";
 
 export default function AppLayout() {
   useRouteProgress();
+  const { user } = useAuth();
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <LoadingBar />
-      <Sidebar />
+      {user && <Sidebar />}
       <main className="p-4">
         <Outlet />
       </main>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,15 +10,22 @@ import NotFound from "@/pages/NotFound";
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <AppLayout />,
     children: [
       { index: true, element: <Landing /> },
       { path: "login", element: <Login /> },
       {
         element: <RequireAuth />,
-        children: [{ path: "dashboard", element: <Dashboard /> }]
+        children: [
+          {
+            element: <AppLayout />,
+            children: [
+              { path: "dashboard", element: <Dashboard /> },
+              { path: "*", element: <NotFound /> },
+            ],
+          },
+        ],
       },
-      { path: "*", element: <NotFound /> }
-    ]
-  }
+      { path: "*", element: <NotFound /> },
+    ],
+  },
 ]);


### PR DESCRIPTION
## Summary
- restrict sidebar to authenticated sessions only
- route login and landing pages outside protected layout
- correct home link to point at dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eabd5daf08330a819c7fb6deb9424