### PR TITLE
feat: improve header toggles and profile menu

### DIFF
--- a/frontend/src/components/common/LanguageToggle.jsx
+++ b/frontend/src/components/common/LanguageToggle.jsx
@@ -1,43 +1,24 @@
 import React from 'react';
 import { Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useLanguage } from '@/context/LanguageContext';
-import { useTranslation } from 'react-i18next';
 
 export function LanguageToggle() {
   const { language, setLanguage } = useLanguage();
-  const { t } = useTranslation();
+
+  const toggleLanguage = () => {
+    setLanguage(language === 'ar' ? 'en' : 'ar');
+  };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="language-switcher">
-          <Globe className="h-[1.2rem] w-[1.2rem]" />
-          <span className="sr-only">Toggle language</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="z-50 bg-popover border border-border">
-        <DropdownMenuItem 
-          onClick={() => setLanguage('ar')} 
-          className={`cursor-pointer ${language === 'ar' ? 'bg-accent' : ''}`}
-        >
-          <span className="font-bold me-2">ع</span>
-          {t('language.arabic')}
-        </DropdownMenuItem>
-        <DropdownMenuItem 
-          onClick={() => setLanguage('en')} 
-          className={`cursor-pointer ${language === 'en' ? 'bg-accent' : ''}`}
-        >
-          <span className="font-bold me-2">En</span>
-          {t('language.english')}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleLanguage}
+      className="language-switcher"
+    >
+      <Globe className="h-[1.2rem] w-[1.2rem]" />
+      <span className="sr-only">Toggle language</span>
+    </Button>
   );
 }

--- a/frontend/src/components/common/ProfileMenu.jsx
+++ b/frontend/src/components/common/ProfileMenu.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { useAuth } from '@/context/AuthContext';
+import { useTranslation } from 'react-i18next';
+
+const getInitials = (name) => {
+  if (!name || typeof name !== 'string') return 'U';
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] || '';
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : '';
+  return (first + last).toUpperCase() || 'U';
+};
+
+export default function ProfileMenu() {
+  const { user, logout } = useAuth();
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Avatar className="h-8 w-8 cursor-pointer">
+          <AvatarFallback>{getInitials(user?.name)}</AvatarFallback>
+        </Avatar>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-popover border border-border">
+        <DropdownMenuItem asChild>
+          <NavLink to="/profile" className="w-full cursor-pointer">
+            {t('navigation.profile')}
+          </NavLink>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={logout} className="cursor-pointer">
+          {t('auth.logout')}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/common/ThemeToggle.jsx
+++ b/frontend/src/components/common/ThemeToggle.jsx
@@ -1,42 +1,28 @@
 import React from 'react';
-import { Moon, Sun, Monitor } from 'lucide-react';
+import { Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useTheme } from '@/context/ThemeContext';
-import { useTranslation } from 'react-i18next';
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const { t } = useTranslation();
+  const { actualTheme, setTheme } = useTheme();
+
+  const toggleTheme = () => {
+    setTheme(actualTheme === 'dark' ? 'light' : 'dark');
+  };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="theme-toggle">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="z-50 bg-popover border border-border">
-        <DropdownMenuItem onClick={() => setTheme('light')} className="cursor-pointer">
-          <Sun className="h-4 w-4 me-2" />
-          {t('theme.light')}
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')} className="cursor-pointer">
-          <Moon className="h-4 w-4 me-2" />
-          {t('theme.dark')}
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')} className="cursor-pointer">
-          <Monitor className="h-4 w-4 me-2" />
-          {t('theme.system')}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="theme-toggle"
+    >
+      {actualTheme === 'dark' ? (
+        <Sun className="h-[1.2rem] w-[1.2rem]" />
+      ) : (
+        <Moon className="h-[1.2rem] w-[1.2rem]" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   );
 }

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { SidebarProvider } from '@/components/ui/sidebar';
-import AppSidebar  from './AppSidebar';
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
+import AppSidebar from './AppSidebar';
 import { Bell, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { useAuth } from '@/context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import { useLanguage } from '@/context/LanguageContext';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { LanguageToggle } from '@/components/common/LanguageToggle';
+import ProfileMenu from '@/components/common/ProfileMenu';
 
 function AppLayout({ children }) {
-  const { user } = useAuth();
   const { t } = useTranslation();
   const { isRTL } = useLanguage();
 
@@ -31,6 +30,7 @@ function AppLayout({ children }) {
           >
             <div className="flex items-center justify-between px-6 h-full">
               <div className={`flex items-center ${isRTL ? 'space-x-reverse' : 'space-x-4'}`}>
+                <SidebarTrigger className="hover:bg-transparent" />
                 <h1 className="text-xl font-semibold text-foreground">
                   {t('app.name')}
                 </h1>
@@ -65,11 +65,8 @@ function AppLayout({ children }) {
                   </Badge>
                 </Button>
 
-                {/* User Info */}
-                <div className={`hidden sm:flex items-center ${isRTL ? 'space-x-reverse' : 'space-x-2'} text-sm`}>
-                  <span className="text-muted-foreground">{t('auth.welcome')}،</span>
-                  <span className="font-medium text-foreground">{user?.name}</span>
-                </div>
+                {/* Profile Menu */}
+                <ProfileMenu />
               </div>
             </div>
           </motion.header>


### PR DESCRIPTION
## Summary
- simplify theme and language toggles to single-click buttons
- add profile dropdown and sidebar toggle in header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0345348a48330a20ca4b4e4fb7725