### PR TITLE
Refactor sidebar layout with animated header toggle

### DIFF
--- a/frontend/src/components/common/HeaderToggle.jsx
+++ b/frontend/src/components/common/HeaderToggle.jsx
@@ -1,31 +1,26 @@
 import React from 'react';
-import { useSidebar } from '../../utils/SidebarContext';
+import { motion } from 'framer-motion';
+import { Menu } from 'lucide-react';
+import { useSidebar } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
 
 function HeaderToggle() {
-  const { isSidebarOpen, setIsSidebarOpen } = useSidebar();
+  const { open, toggleSidebar } = useSidebar();
 
   return (
-    <button
-    className="text-white mr-2 hover:text-almadar-sidebar-danger dark:text-almadar-mint-light dark:hover:text-almadar-sand transition-colors duration-300 ease-in-out"
-    onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+    <Button
+      variant="ghost"
+      size="icon"
+      className="text-white mr-2 hover:text-almadar-sidebar-danger dark:text-almadar-mint-light dark:hover:text-almadar-sand transition-colors duration-300 ease-in-out"
+      onClick={toggleSidebar}
       aria-controls="sidebar"
-      aria-expanded={isSidebarOpen}
+      aria-expanded={open}
+      aria-label={open ? 'Close sidebar' : 'Open sidebar'}
     >
-      <span className="sr-only">
-        {isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
-      </span>
-      <svg
-        className="w-6 h-6 fill-current"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        {isSidebarOpen ? (
-          <path d="M13.3 5.3l-1.4 1.4L16.2 11H4v2h12.2l-4.3 4.3 1.4 1.4L20 12z" />
-        ) : (
-          <path d="M10.7 18.7l1.4-1.4L7.8 13H20v-2H7.8l4.3-4.3-1.4-1.4L4 12z" />
-        )}
-      </svg>
-    </button>
+      <motion.div animate={{ rotate: open ? 180 : 0 }} transition={{ duration: 0.3 }}>
+        <Menu className="w-6 h-6" />
+      </motion.div>
+    </Button>
   );
 }
 

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
+import { SidebarProvider } from '@/components/ui/sidebar';
 import AppSidebar from './AppSidebar';
 import { Bell, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -11,14 +11,16 @@ import { useLanguage } from '@/context/LanguageContext';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import { LanguageToggle } from '@/components/common/LanguageToggle';
 import ProfileMenu from '@/components/common/ProfileMenu';
+import HeaderToggle from '@/components/common/HeaderToggle';
 
 function AppLayout({ children }) {
   const { t } = useTranslation();
   const { isRTL } = useLanguage();
 
   return (
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={false}>
       <div className="min-h-screen flex w-full bg-background">
+        <AppSidebar />
 
         <div className="flex-1 flex flex-col overflow-hidden">
           {/* Header */}
@@ -29,13 +31,12 @@ function AppLayout({ children }) {
           >
             <div className="flex items-center justify-between px-6 h-full">
               <div className={`flex items-center ${isRTL ? 'space-x-reverse' : 'space-x-4'}`}>
-                <SidebarTrigger className="hover:bg-transparent" />
+                <HeaderToggle />
                 <h1 className="text-xl font-semibold text-foreground">
                   {t('app.name')}
                 </h1>
               </div>
 
-        <AppSidebar />
               <div className={`flex items-center ${isRTL ? 'space-x-reverse' : 'space-x-4'}`}>
                 {/* Search */}
                 <div className="relative hidden md:block">


### PR DESCRIPTION
## Summary
- Position `AppSidebar` outside the header and start collapsed by default
- Add animated menu button in header to toggle sidebar state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04d866c7c833086538b781af9a7fc