### PR TITLE
Fix sidebar accessibility and toggle

### DIFF
--- a/frontend/src/components/common/HeaderToggle.jsx
+++ b/frontend/src/components/common/HeaderToggle.jsx
@@ -5,16 +5,25 @@ import { useSidebar } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 
 function HeaderToggle() {
-  const { open, toggleSidebar } = useSidebar();
+  // Many shadcn sidebar recipes expose { open, setOpen } and not toggleSidebar
+  const { open, setOpen, toggleSidebar } = useSidebar();
+
+  const handleClick = () => {
+    if (typeof toggleSidebar === 'function') {
+      toggleSidebar();
+    } else if (typeof setOpen === 'function') {
+      setOpen(!open);
+    }
+  };
 
   return (
     <Button
       variant="ghost"
       size="icon"
       className="text-white mr-2 hover:text-almadar-sidebar-danger dark:text-almadar-mint-light dark:hover:text-almadar-sand transition-colors duration-300 ease-in-out"
-      onClick={toggleSidebar}
-      aria-controls="sidebar"
-      aria-expanded={open}
+      onClick={handleClick}
+      aria-controls="app-sidebar"
+      aria-expanded={!!open}
       aria-label={open ? 'Close sidebar' : 'Open sidebar'}
     >
       <motion.div animate={{ rotate: open ? 180 : 0 }} transition={{ duration: 0.3 }}>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -94,6 +94,7 @@ export default function AppSidebar() {
 
   return (
     <Sidebar
+      id="app-sidebar"
       className={`${collapsed ? 'w-16' : 'w-64'} sidebar-transition border-r border-sidebar-border`}
       collapsible="icon"
     >

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
@@ -204,6 +204,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetTitle className="sr-only">Sidebar Navigation</SheetTitle>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
## Summary
- add hidden SheetTitle to sidebar SheetContent to satisfy Radix title requirement
- make HeaderToggle fallback to setOpen and use aria-controls with matching sidebar id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a051a9c9c48330b6a8b4f0645f8e1a