### PR TITLE
Fix topbar sidebar toggle

### DIFF
--- a/frontend/src/components/layout/Topbar.jsx
+++ b/frontend/src/components/layout/Topbar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Moon, SunMedium } from 'lucide-react';
 import Button from '@/components/ui/Button';
+import HeaderToggle from '@/components/common/HeaderToggle';
 
 export default function Topbar() {
   const [dark, setDark] = useState(
@@ -22,9 +23,13 @@ export default function Topbar() {
     <header className="sticky top-0 z-50 border-b border-border/60 bg-bg/70 backdrop-blur">
       <div className="container flex items-center justify-between py-3">
         <div className="flex items-center gap-3">
+          {/* Sidebar toggle button */}
+          <HeaderToggle />
+
           <div className="pill">المــدار</div>
           <span className="text-sm text-muted">منصة الإدارة القانونية الذكية</span>
         </div>
+
         <div className="flex items-center gap-2">
           <Button variant="ghost" onClick={() => setDark(!dark)} aria-label="Toggle theme">
             {dark ? <SunMedium className="w-5 h-5" /> : <Moon className="w-5 h-5" />}


### PR DESCRIPTION
## Summary
- add HeaderToggle to topbar so sidebar can be toggled from header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a05384fcb4833082b9b78316720cd8