### PR TITLE
fix: improve sidebar responsiveness

### DIFF
--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -95,6 +95,7 @@ export default function AppSidebar() {
   return (
     <Sidebar
       id="app-sidebar"
+      side={isRTL ? 'right' : 'left'}
       className={`${collapsed ? 'w-16' : 'w-64'} sidebar-transition border-r border-sidebar-border`}
       collapsible="icon"
     >

--- a/frontend/src/context/LanguageContext.tsx
+++ b/frontend/src/context/LanguageContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface LanguageContextType {
@@ -17,6 +17,12 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   };
 
   const isRTL = i18n.language === 'ar';
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+    }
+  }, [isRTL]);
 
   return (
     <LanguageContext.Provider value={{ 


### PR DESCRIPTION
## Summary
- persist sidebar state in localStorage only on desktop and expose collapsed/mobile flags
- respect RTL layout by positioning sidebar on the right when needed
- update document direction based on current language

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a06bb604808330b1a1d37d9c860125