### PR TITLE
Persist sidebar state with RTL support

### DIFF
--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
@@ -73,13 +73,27 @@ const getAdminItems = (t) => [
 ];
 
 export default function AppSidebar() {
-  const { open } = useSidebar(); // from shadcn/ui
+  const { open, setOpen, isCollapsed } = useSidebar(); // from shadcn/ui
   const location = useLocation();
   const { user, logout } = useAuth();
   const { t } = useTranslation();
   const { isRTL } = useLanguage();
 
-  const collapsed = !open;
+  const collapsed = isCollapsed;
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('sidebar:collapsed');
+      if (stored !== null) {
+        setOpen(!JSON.parse(stored));
+      }
+    }
+  }, [setOpen]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('sidebar:collapsed', JSON.stringify(collapsed));
+    }
+  }, [collapsed]);
   const currentPath = location.pathname;
 
   const isActivePath = (path) => currentPath === path;

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -16,8 +16,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useLanguage } from "@/context/LanguageContext"
 
-const SIDEBAR_STORAGE_KEY = "sidebar:state"
+const SIDEBAR_STORAGE_KEY = "sidebar:collapsed"
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
@@ -77,7 +78,7 @@ const SidebarProvider = React.forwardRef<
       if (typeof window !== "undefined" && window.innerWidth >= 768) {
         const storedState = localStorage.getItem(SIDEBAR_STORAGE_KEY)
         if (storedState !== null) {
-          _setOpen(storedState === "true")
+          _setOpen(!JSON.parse(storedState))
         }
       }
     }, [])
@@ -95,7 +96,7 @@ const SidebarProvider = React.forwardRef<
         if (typeof window !== "undefined" && window.innerWidth >= 768) {
           localStorage.setItem(
             SIDEBAR_STORAGE_KEY,
-            JSON.stringify(openState)
+            JSON.stringify(!openState)
           )
         }
       },
@@ -181,7 +182,7 @@ const Sidebar = React.forwardRef<
 >(
   (
     {
-      side = "left",
+      side,
       variant = "sidebar",
       collapsible = "offcanvas",
       className,
@@ -191,6 +192,8 @@ const Sidebar = React.forwardRef<
     ref
   ) => {
     const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+    const { isRTL } = useLanguage()
+    const resolvedSide = side ?? (isRTL ? "right" : "left")
 
     if (collapsible === "none") {
       return (
@@ -219,7 +222,7 @@ const Sidebar = React.forwardRef<
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
               } as React.CSSProperties
             }
-            side={side}
+            side={resolvedSide}
           >
             {/* Hidden title for accessibility requirements */}
             <SheetTitle className="sr-only">Sidebar Navigation</SheetTitle>
@@ -236,7 +239,7 @@ const Sidebar = React.forwardRef<
         data-state={state}
         data-collapsible={state === "collapsed" ? collapsible : ""}
         data-variant={variant}
-        data-side={side}
+        data-side={resolvedSide}
       >
         {/* This is what handles the sidebar gap on desktop */}
         <div
@@ -252,7 +255,7 @@ const Sidebar = React.forwardRef<
         <div
           className={cn(
             "duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex",
-            side === "left"
+            resolvedSide === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.

--- a/frontend/src/context/LanguageContext.tsx
+++ b/frontend/src/context/LanguageContext.tsx
@@ -9,18 +9,32 @@ interface LanguageContextType {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+const LANGUAGE_STORAGE_KEY = 'app-language';
+
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { i18n } = useTranslation();
 
   const setLanguage = (lang: string) => {
     i18n.changeLanguage(lang);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+    }
   };
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+      if (saved && saved !== i18n.language) {
+        i18n.changeLanguage(saved);
+      }
+    }
+  }, [i18n]);
 
   const isRTL = i18n.language === 'ar';
 
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+      document.documentElement.setAttribute('dir', isRTL ? 'rtl' : 'ltr');
     }
   }, [isRTL]);
 


### PR DESCRIPTION
## Summary
- persist sidebar collapsed state across sessions
- align sidebar to right side in RTL locales
- sync document direction with saved language

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a070ea8a388330a477acffbbd55cdf