### PR TITLE
fix: export AppSidebar correctly and adjust layout

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { SidebarProvider, useSidebar } from '@/components/ui/sidebar';
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from './AppSidebar';
-import { Bell, Search } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/context/AuthContext';
-import { PanelLeft } from 'lucide-react';
 
 const AppLayout = ({ children }) => {
   const { user } = useAuth();
-  const { toggleSidebar } = useSidebar();  // Ensure useSidebar is used here
 
   return (
     <SidebarProvider>
@@ -34,14 +30,7 @@ const AppLayout = ({ children }) => {
 
               <div className="flex items-center space-x-4 space-x-reverse">
                 {/* Toggle Sidebar Button */}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="md:hidden"
-                  onClick={() => toggleSidebar()}  // Toggle the sidebar state
-                >
-                  <PanelLeft className="h-5 w-5" />
-                </Button>
+                <SidebarTrigger className="md:hidden" />
 
                 {/* Search */}
                 <div className="relative hidden md:block">

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -84,7 +84,7 @@ const adminItems = [
   },
 ];
 
-export function AppSidebar() {
+function AppSidebar() {
   const { open, toggleSidebar } = useSidebar();
   const location = useLocation();
   const { user, logout } = useAuth();
@@ -220,3 +220,5 @@ export function AppSidebar() {
     </Sidebar>
   );
 }
+
+export default AppSidebar;


### PR DESCRIPTION
## Summary
- ensure AppSidebar provides a default export
- use built-in SidebarTrigger and clean up unused imports in AppLayout

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not load /workspace/almadar/frontend/src/components/auth/AuthContext)*

------
https://chatgpt.com/codex/tasks/task_e_68a08db7e7088330b8f5cc065f1b5191