### PR TITLE
feat: responsive sidebar with language and theme controls

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -4,14 +4,21 @@ import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from './AppSidebar';
 import { Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { useAuth } from '@/context/AuthContext';
+import { LanguageToggle } from '@/components/common/LanguageToggle';
+import { ThemeToggle } from '@/components/common/ThemeToggle';
+import ProfileMenu from '@/components/common/ProfileMenu';
+import { useLanguage } from '@/context/LanguageContext';
 
 const AppLayout = ({ children }) => {
-  const { user } = useAuth();
+  const { isRTL } = useLanguage();
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-background">
+      <div
+        className={`min-h-screen flex w-full bg-background ${
+          isRTL ? 'flex-row-reverse' : ''
+        }`}
+      >
         <AppSidebar />
 
         <div className="flex-1 flex flex-col overflow-hidden">
@@ -23,20 +30,20 @@ const AppLayout = ({ children }) => {
           >
             <div className="flex items-center justify-between px-6 h-full">
               <div className="flex items-center space-x-4 space-x-reverse">
+                <SidebarTrigger className="md:hidden" />
                 <h1 className="text-xl font-semibold text-foreground">
                   منصة المدار
                 </h1>
-              </div>
-
-              <div className="flex items-center space-x-4 space-x-reverse">
-                {/* Toggle Sidebar Button */}
-                <SidebarTrigger className="md:hidden" />
-
-                {/* Search */}
                 <div className="relative hidden md:block">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input placeholder="البحث..." className="pl-10 w-64 focus-ring" />
                 </div>
+              </div>
+
+              <div className="flex items-center space-x-2 space-x-reverse">
+                <LanguageToggle />
+                <ThemeToggle />
+                <ProfileMenu />
               </div>
             </div>
           </motion.header>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -29,6 +29,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { useAuth } from '@/context/AuthContext';
+import { useLanguage } from '@/context/LanguageContext';
 
 const navigationItems = [
   {
@@ -85,9 +86,10 @@ const adminItems = [
 ];
 
 function AppSidebar() {
-  const { open, toggleSidebar } = useSidebar();
+  const { open } = useSidebar();
   const location = useLocation();
   const { user, logout } = useAuth();
+  const { isRTL } = useLanguage();
   const currentPath = location.pathname;
   const collapsed = !open;
 
@@ -104,10 +106,17 @@ function AppSidebar() {
 
   return (
     <Sidebar
-      className={`${collapsed ? 'w-16' : 'w-64'} sidebar-transition border-r border-sidebar-border`}
+      side={isRTL ? 'right' : 'left'}
+      className={`${collapsed ? 'w-16' : 'w-64'} sidebar-transition ${
+        isRTL ? 'border-l' : 'border-r'
+      } border-sidebar-border`}
       collapsible="icon"
     >
-      <SidebarContent className="bg-sidebar">
+      <SidebarContent
+        className={`bg-sidebar ${
+          isRTL ? 'animate-slide-in-right' : 'animate-slide-in-left'
+        }`}
+      >
         {/* User Profile Section */}
         {!collapsed && (
           <motion.div
@@ -146,7 +155,11 @@ function AppSidebar() {
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
                       <NavLink to={item.url} className={getNavCls}>
-                        <item.icon className={`h-5 w-5 ${collapsed ? 'mx-auto' : 'mr-3'}`} />
+                        <item.icon
+                          className={`h-5 w-5 ${
+                            collapsed ? 'mx-auto' : isRTL ? 'ml-3' : 'mr-3'
+                          }`}
+                        />
                         {!collapsed && (
                           <>
                             <span className="flex-1">{item.title}</span>
@@ -175,7 +188,11 @@ function AppSidebar() {
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton asChild>
                         <NavLink to={item.url} className={getNavCls}>
-                          <item.icon className={`h-5 w-5 ${collapsed ? 'mx-auto' : 'mr-3'}`} />
+                          <item.icon
+                            className={`h-5 w-5 ${
+                              collapsed ? 'mx-auto' : isRTL ? 'ml-3' : 'mr-3'
+                            }`}
+                          />
                           {!collapsed && (
                             <>
                               <span className="flex-1">{item.title}</span>
@@ -201,7 +218,7 @@ function AppSidebar() {
             asChild
           >
             <NavLink to="/profile">
-              <User className={`h-4 w-4 ${collapsed ? '' : 'mr-2'}`} />
+              <User className={`h-4 w-4 ${collapsed ? '' : isRTL ? 'ml-2' : 'mr-2'}`} />
               {!collapsed && 'الملف الشخصي'}
             </NavLink>
           </Button>
@@ -212,7 +229,7 @@ function AppSidebar() {
             onClick={logout}
             className="w-full justify-start text-sidebar-foreground hover:bg-destructive hover:text-destructive-foreground"
           >
-            <LogOut className={`h-4 w-4 ${collapsed ? '' : 'mr-2'}`} />
+            <LogOut className={`h-4 w-4 ${collapsed ? '' : isRTL ? 'ml-2' : 'mr-2'}`} />
             {!collapsed && 'تسجيل الخروج'}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- orient sidebar based on selected language with slide-in animation
- add language and theme toggles plus profile menu to header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0c26df3d48330964a394745bc0b1b