### PR TITLE
fix: navigate to dashboard after login

### DIFF
--- a/frontend/src/components/auth/LoginForm.jsx
+++ b/frontend/src/components/auth/LoginForm.jsx
@@ -18,8 +18,8 @@ const LoginForm = ({ onSuccess }) => {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const success = await login(email, password);
-      if (success && typeof onSuccess === 'function') onSuccess();
+      const result = await login(email, password);
+      if (result?.success && typeof onSuccess === 'function') onSuccess();
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -18,6 +18,7 @@ export const AuthContext = createContext({
   token: null,
   roles: [],
   permissions: [],
+  isAuthenticated: false,
   login: async () => false,
   logout: () => {},
   hasRole: () => false,
@@ -53,6 +54,8 @@ export function AuthProvider({ children }) {
 
   const [loading, setLoading] = useState(true);
 
+  const isAuthenticated = !!token;
+
   /**
    * دالة حفظ بيانات الجلسة والتحديث في السياق
    */
@@ -67,7 +70,7 @@ export function AuthProvider({ children }) {
     setRoles(rl);
     setPermissions(pr);
 
-    navigate('/');
+    navigate('/dashboard');
   };
 
   /**
@@ -216,6 +219,7 @@ export function AuthProvider({ children }) {
       token,
       roles,
       permissions,
+      isAuthenticated,
       login,
       logout,
       hasRole,
@@ -224,7 +228,7 @@ export function AuthProvider({ children }) {
       updatePermissions,
       http: api,
     }),
-    [user, token, roles, permissions]
+    [user, token, roles, permissions, isAuthenticated]
   );
 
   if (loading) return <div><AuthSpinner/></div>;


### PR DESCRIPTION
## Summary
- expose `isAuthenticated` in auth context and send users to `/dashboard` after saving login info
- ensure login form only closes on successful authentication

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb531dc4833093425ea7cd4cea01