### PR TITLE
Fix mobile sidebar visibility and toggling

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -17,7 +17,7 @@ const AppLayout = ({ children }) => {
   const { isRTL } = useLanguage();
 
   return (
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={false}>
       <AppSidebar />
       <SidebarInset dir={isRTL ? 'rtl' : 'ltr'} className="flex flex-col">
         {/* Header */}
@@ -28,7 +28,7 @@ const AppLayout = ({ children }) => {
         >
           <div className="flex items-center justify-between px-6 h-full">
             <div className="flex items-center space-x-4 space-x-reverse">
-              <SidebarTrigger />
+              <SidebarTrigger className="md:hidden" />
               <h1 className="text-xl font-semibold text-foreground">
                 منصة المدار
               </h1>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -85,7 +85,7 @@ const adminItems = [
   },
 ];
 function AppSidebar() {
-  const { state } = useSidebar();
+  const { state, isMobile, setOpenMobile } = useSidebar();
   const location = useLocation();
   const { user, logout } = useAuth();
   const { isRTL } = useLanguage();
@@ -101,6 +101,10 @@ function AppSidebar() {
 
   const hasPermission = (permission) => {
     return user?.role === 'Admin' || user?.permissions?.includes(permission);
+  };
+
+  const handleLinkClick = () => {
+    if (isMobile) setOpenMobile(false);
   };
 
   return (
@@ -142,7 +146,7 @@ function AppSidebar() {
         )}
 
         {/* Toggle Button */}
-        <div className="p-2">
+        <div className="p-2 hidden md:block">
           <SidebarTrigger className="w-full justify-center hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" />
         </div>
 
@@ -157,7 +161,11 @@ function AppSidebar() {
                 hasPermission(item.permission) ? (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
-                      <NavLink to={item.url} className={getNavCls}>
+                      <NavLink
+                        to={item.url}
+                        className={getNavCls}
+                        onClick={handleLinkClick}
+                      >
                         <item.icon
                           className={`h-5 w-5 ${
                             collapsed ? 'mx-auto' : isRTL ? 'ml-3' : 'mr-3'
@@ -190,7 +198,11 @@ function AppSidebar() {
                   hasPermission(item.permission) ? (
                     <SidebarMenuItem key={item.title}>
                       <SidebarMenuButton asChild>
-                        <NavLink to={item.url} className={getNavCls}>
+                        <NavLink
+                          to={item.url}
+                          className={getNavCls}
+                          onClick={handleLinkClick}
+                        >
                           <item.icon
                             className={`h-5 w-5 ${
                               collapsed ? 'mx-auto' : isRTL ? 'ml-3' : 'mr-3'
@@ -220,7 +232,7 @@ function AppSidebar() {
             className="w-full justify-start text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             asChild
           >
-            <NavLink to="/profile">
+            <NavLink to="/profile" onClick={handleLinkClick}>
               <User className={`h-4 w-4 ${collapsed ? '' : isRTL ? 'ml-2' : 'mr-2'}`} />
               {!collapsed && 'الملف الشخصي'}
             </NavLink>
@@ -229,7 +241,10 @@ function AppSidebar() {
           <Button
             variant="ghost"
             size={collapsed ? 'icon' : 'sm'}
-            onClick={logout}
+            onClick={() => {
+              if (isMobile) setOpenMobile(false);
+              logout();
+            }}
             className="w-full justify-start text-sidebar-foreground hover:bg-destructive hover:text-destructive-foreground"
           >
             <LogOut className={`h-4 w-4 ${collapsed ? '' : isRTL ? 'ml-2' : 'mr-2'}`} />

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -35,7 +35,7 @@ Slot.displayName = "Slot"
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_MOBILE = "100vw"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
@@ -81,12 +81,10 @@ const SidebarProvider = React.forwardRef<
     ref
   ) => {
     const isMobile = useIsMobile()
-    const [openMobile, setOpenMobile] = React.useState(isMobile)
+    const [openMobile, setOpenMobile] = React.useState(false)
 
     React.useEffect(() => {
-      if (isMobile) {
-        setOpenMobile(true)
-      }
+      setOpenMobile(false)
     }, [isMobile])
 
     // This is the internal state of the sidebar.
@@ -217,7 +215,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-[--sidebar-width] sm:max-w-full bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
## Summary
- start layout with sidebar closed and header toggle only on mobile
- close sidebar after mobile navigation and logout
- prevent auto-open on mobile and use full-width sheet

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c84a195c8330af0fb1bd366e4b9e