### PR TITLE
feat: open sidebar by default on larger screens

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -12,12 +12,14 @@ import { LanguageToggle } from '@/components/common/LanguageToggle';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import ProfileMenu from '@/components/common/ProfileMenu';
 import { useLanguage } from '@/context/LanguageContext';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 const AppLayout = ({ children }) => {
   const { isRTL } = useLanguage();
+  const isMobile = useIsMobile();
 
   return (
-    <SidebarProvider defaultOpen={false}>
+    <SidebarProvider defaultOpen={!isMobile}>
       <AppSidebar />
       <SidebarInset dir={isRTL ? 'rtl' : 'ltr'} className="flex flex-col">
         {/* Header */}


### PR DESCRIPTION
## Summary
- open sidebar by default on desktop using `useIsMobile`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a1d2933af88330a71878048cd74641