### PR TITLE
feat: add responsive sidebar with theme support

### DIFF
--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -1,115 +1,152 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
-import { DashboardIcon, ContractsIcon, ConsultationsIcon, LawsuitsIcon, ArchiveIcon, CourtHouseIcon, LawBookIcon, LegalBriefcaseIcon } from '@/components/ui/Icons';
+import {
+  DashboardIcon,
+  ContractsIcon,
+  ConsultationsIcon,
+  LawsuitsIcon,
+  ArchiveIcon,
+  CourtHouseIcon,
+  LawBookIcon,
+  LegalBriefcaseIcon,
+} from '@/components/ui/Icons';
 
-export default function AppSidebar({ isOpen, onToggle, onLinkClick, isRTL }) {
+export default function AppSidebar({
+  isOpen,
+  toggleSidebar,
+  closeSidebar,
+  isMobile,
+  isRTL,
+}) {
   const [activeSection, setActiveSection] = useState(null);
-  const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth >= 1024);
 
-  useEffect(() => {
-    const handleResize = () => setIsLargeScreen(window.innerWidth >= 1024);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const logoSrc = isOpen ? '/path-to-logo-open' : '/path-to-logo-closed';
-
-  const navConfig = useMemo(() => [
-    { id: 'home', label: 'الرئيسية', to: '/', icon: <DashboardIcon size={20} /> },
-    { id: 'contracts', label: 'التعاقدات', to: '/contracts', icon: <ContractsIcon size={20} /> },
-    {
-      id: 'fatwa', label: 'الرأي والفتوى', icon: <ConsultationsIcon size={20} />, children: [
-        { id: 'investigations', label: 'التحقيقات', to: '/legal/investigations', icon: <LawsuitsIcon size={16} /> },
-        { id: 'legal-advices', label: 'المشورة القانونية', to: '/legal/legal-advices', icon: <LawBookIcon size={16} /> },
-        { id: 'litigations', label: 'التقاضي', to: '/legal/litigations', icon: <CourtHouseIcon size={16} /> },
-      ]
-    },
-    {
-      id: 'management', label: 'إدارة التطبيق', icon: <LegalBriefcaseIcon size={20} />, children: [
-        { id: 'lists', label: 'القوائم', to: '/managment-lists', icon: <LegalBriefcaseIcon size={16} /> },
-      ]
-    },
-    {
-      id: 'users', label: 'إدارة المستخدمين', icon: <LegalBriefcaseIcon size={20} />, children: [
-        { id: 'users-list', label: 'المستخدمين', to: '/users', icon: <LegalBriefcaseIcon size={16} /> },
-      ]
-    },
-    { id: 'archive', label: 'الأرشيف', to: '/archive', icon: <ArchiveIcon size={20} /> },
-  ], []);
+  const navConfig = useMemo(
+    () => [
+      { id: 'home', label: 'الرئيسية', to: '/', icon: <DashboardIcon size={20} /> },
+      { id: 'contracts', label: 'التعاقدات', to: '/contracts', icon: <ContractsIcon size={20} /> },
+      {
+        id: 'fatwa',
+        label: 'الرأي والفتوى',
+        icon: <ConsultationsIcon size={20} />,
+        children: [
+          { id: 'investigations', label: 'التحقيقات', to: '/legal/investigations', icon: <LawsuitsIcon size={16} /> },
+          { id: 'legal-advices', label: 'المشورة القانونية', to: '/legal/legal-advices', icon: <LawBookIcon size={16} /> },
+          { id: 'litigations', label: 'التقاضي', to: '/legal/litigations', icon: <CourtHouseIcon size={16} /> },
+        ],
+      },
+      {
+        id: 'management',
+        label: 'إدارة التطبيق',
+        icon: <LegalBriefcaseIcon size={20} />,
+        children: [
+          { id: 'lists', label: 'القوائم', to: '/managment-lists', icon: <LegalBriefcaseIcon size={16} /> },
+        ],
+      },
+      {
+        id: 'users',
+        label: 'إدارة المستخدمين',
+        icon: <LegalBriefcaseIcon size={20} />,
+        children: [
+          { id: 'users-list', label: 'المستخدمين', to: '/users', icon: <LegalBriefcaseIcon size={16} /> },
+        ],
+      },
+      { id: 'archive', label: 'الأرشيف', to: '/archive', icon: <ArchiveIcon size={20} /> },
+    ],
+    []
+  );
 
   const handleSectionClick = (id, hasChildren) => {
-    if (!isLargeScreen && !isOpen) onToggle();
-    if (hasChildren) setActiveSection(prev => (prev === id ? null : id));
+    if (hasChildren) {
+      setActiveSection((prev) => (prev === id ? null : id));
+    } else if (isMobile) {
+      closeSidebar();
+    }
   };
 
-  const getNavCls = (isActive) =>
-    isActive 
-      ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium" 
-      : "hover:bg-sidebar-accent/50 text-sidebar-foreground hover:text-sidebar-accent-foreground";
+  const side = isRTL ? 'right-0' : 'left-0';
+  const translate = isMobile
+    ? isOpen
+      ? 'translate-x-0'
+      : isRTL
+        ? 'translate-x-full'
+        : '-translate-x-full'
+    : 'translate-x-0';
+  const width = isMobile ? 'w-64' : isOpen ? 'w-64' : 'w-16';
 
   return (
     <aside
       dir={isRTL ? 'rtl' : 'ltr'}
-      className={`fixed top-0 z-20 h-full bg-gradient-to-b from-gold via-greenic-dark/50 to-royal/80 transition-all duration-300
-        ${isLargeScreen ? (isOpen ? 'w-64' : 'w-16') : (isOpen ? 'w-full mt-16' : 'translate-x-full')}`}
+      className={`fixed top-0 z-40 h-full ${side} ${width} ${translate} flex flex-col bg-sidebar text-sidebar-foreground transition-all duration-300`}
     >
-      <div className="flex items-center justify-center p-0 mt-6">
-        <img
-          src={logoSrc}
-          alt="Logo"
-          className={`transition-all duration-300 ${isOpen ? 'w-36' : 'w-10'}`}
-        />
-        {isOpen && <button onClick={onToggle} className="absolute top-4 left-4">×</button>}
+      <div className={`flex items-center ${isOpen ? 'justify-between' : 'justify-center'} p-4`}>
+        {isOpen && <span className="font-bold">Almadar</span>}
+        <button
+          onClick={toggleSidebar}
+          className="p-2 rounded-md hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+        >
+          <ChevronRight
+            className={`h-4 w-4 transition-transform ${isRTL ? 'rotate-180' : ''} ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </button>
       </div>
 
-      <nav className={`${isOpen ? 'px-4 space-y-4 mt-6' : 'px-2 space-y-2 mt-8'} overflow-y-auto h-full`}>
-        {navConfig.map(item => (
-          <div key={item.id}>
+      <nav className={`flex-1 space-y-1 overflow-y-auto ${isOpen ? 'px-4' : 'px-2'}`}>
+        {navConfig.map((item) => (
+          <div key={item.id} className="text-sm">
             {item.to ? (
               <NavLink
                 to={item.to}
-                onClick={onLinkClick}
-                className={({ isActive }) => `${getNavCls(isActive)} flex items-center gap-3 p-2 rounded-md text-sm font-semibold tracking-tight transition-all duration-300`}
+                onClick={isMobile ? closeSidebar : undefined}
+                className={({ isActive }) =>
+                  `flex items-center gap-3 rounded-md p-2 transition-colors ${
+                    isActive
+                      ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
+                      : 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                  } ${!isOpen && !isMobile ? 'justify-center' : ''}`
+                }
               >
-                {({ isActive }) => (
-                  <>
-                    {React.cloneElement(item.icon, { className: `transition-colors duration-200 ${isActive ? 'text-gold-light' : 'text-white'}` })}
-                    <span className="flex-1 text-right">{item.label}</span>
-                  </>
-                )}
+                {item.icon}
+                {(isOpen || isMobile) && <span className="flex-1 truncate">{item.label}</span>}
               </NavLink>
             ) : (
               <button
                 onClick={() => handleSectionClick(item.id, !!item.children)}
-                className={`flex items-center gap-3 p-2 w-full rounded-md text-sm font-semibold tracking-tight transition-colors duration-200
-                  ${activeSection === item.id ? 'bg-gold-light text-greenic' : 'text-white hover:bg-gold-light'}`}
+                className={`flex w-full items-center gap-3 rounded-md p-2 transition-colors ${
+                  activeSection === item.id
+                    ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
+                    : 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                } ${!isOpen && !isMobile ? 'justify-center' : ''}`}
               >
-                {React.cloneElement(item.icon, {
-                  className: `transition-colors duration-200 ${activeSection === item.id ? 'text-gold-light' : 'text-white'}`,
-                })}
-                <span className="flex-1 text-right">{item.label}</span>
-                {item.children && <ChevronRight className={`w-4 h-4 transform transition-transform duration-200 ${activeSection === item.id ? 'rotate-90' : ''}`} />}
+                {item.icon}
+                {(isOpen || isMobile) && <span className="flex-1 truncate">{item.label}</span>}
+                {item.children && (isOpen || isMobile) && (
+                  <ChevronRight
+                    className={`h-4 w-4 transition-transform ${
+                      activeSection === item.id ? (isRTL ? '-rotate-90' : 'rotate-90') : ''
+                    }`}
+                  />
+                )}
               </button>
             )}
 
-            {item.children && activeSection === item.id && isOpen && (
-              <div className="mr-4 pl-4 border-r border-gray-600 space-y-1">
-                {item.children.map(child => (
+            {item.children && activeSection === item.id && (isOpen || isMobile) && (
+              <div className="mt-1 space-y-1 border-r border-sidebar-border pr-4">
+                {item.children.map((child) => (
                   <NavLink
                     key={child.id}
                     to={child.to}
-                    onClick={onLinkClick}
-                    className={({ isActive }) => `${getNavCls(isActive)} flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-300`}
+                    onClick={isMobile ? closeSidebar : undefined}
+                    className={({ isActive }) =>
+                      `flex items-center gap-2 rounded-md px-4 py-2 text-sm transition-colors ${
+                        isActive
+                          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                          : 'hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground'
+                      }`
+                    }
                   >
-                    {({ isActive }) => (
-                      <>
-                        {React.cloneElement(child.icon, {
-                          className: `transition duration-200 ${isActive ? 'text-greenic-dark' : 'text-white'}`,
-                        })}
-                        <span>{child.label}</span>
-                      </>
-                    )}
+                    {child.icon}
+                    <span className="truncate">{child.label}</span>
                   </NavLink>
                 ))}
               </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,12 @@
     --primary-foreground: 0 0% 98%;
     --primary-hover: 218 40% 20%;
     --primary-light: 218 25% 35%;
+
+    /* CSS color tokens for Tailwind config */
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary));
+    --accent-color: hsl(var(--accent));
+    --background-color: hsl(var(--background));
     
     /* Secondary Colors - Professional Blue */
     --secondary: 210 20% 94%;
@@ -103,6 +109,12 @@
     --primary-foreground: 218 30% 8%;
     --primary-hover: 214 90% 70%;
     --primary-light: 214 80% 75%;
+
+    /* CSS color tokens for Tailwind config */
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary));
+    --accent-color: hsl(var(--accent));
+    --background-color: hsl(var(--background));
     
     --secondary: 218 20% 18%;
     --secondary-foreground: 210 15% 85%;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -12,19 +12,19 @@ module.exports = {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))',
-					hover: 'hsl(var(--primary-hover))',
-					light: 'hsl(var(--primary-light))'
-				},
-				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))',
-					hover: 'hsl(var(--secondary-hover))'
-				},
+                                background: 'var(--background-color)',
+                                foreground: 'hsl(var(--foreground))',
+                                primary: {
+                                        DEFAULT: 'var(--primary-color)',
+                                        foreground: 'hsl(var(--primary-foreground))',
+                                        hover: 'hsl(var(--primary-hover))',
+                                        light: 'hsl(var(--primary-light))'
+                                },
+                                secondary: {
+                                        DEFAULT: 'var(--secondary-color)',
+                                        foreground: 'hsl(var(--secondary-foreground))',
+                                        hover: 'hsl(var(--secondary-hover))'
+                                },
 				destructive: {
 					DEFAULT: 'hsl(var(--destructive))',
 					foreground: 'hsl(var(--destructive-foreground))'
@@ -41,11 +41,11 @@ module.exports = {
 					DEFAULT: 'hsl(var(--muted))',
 					foreground: 'hsl(var(--muted-foreground))'
 				},
-				accent: {
-					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))',
-					hover: 'hsl(var(--accent-hover))'
-				},
+                                accent: {
+                                        DEFAULT: 'var(--accent-color)',
+                                        foreground: 'hsl(var(--accent-foreground))',
+                                        hover: 'hsl(var(--accent-hover))'
+                                },
 				popover: {
 					DEFAULT: 'hsl(var(--popover))',
 					foreground: 'hsl(var(--popover-foreground))'


### PR DESCRIPTION
## Summary
- add CSS color tokens for primary, secondary, accent and background
- map Tailwind theme colors to CSS variables for light/dark themes
- rebuild sidebar with RTL/LTR support and responsive collapse/expand behavior

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef644fb083309d7d3bce889e347c