### PR TITLE
feat: centralize permission-based access control

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,44 @@
 import React from 'react';
-import Topbar from '@/components/layout/Topbar';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from '@/components/auth/AuthContext';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import AppSidebar from '@/components/layout/AppSidebar';
 import Home from '@/pages/Home';
+import ContractsPage from '@/pages/ContractsPage';
+import Forbidden from '@/pages/Forbidden';
+import ProtectedRoute from '@/components/auth/ProtectedRoute';
 
 export default function App() {
   return (
-    <>
-      <Topbar />
-      <Home />
-    </>
+    <BrowserRouter>
+      <AuthProvider>
+        <div className="flex min-h-screen">
+          <SidebarProvider>
+            <AppSidebar />
+          </SidebarProvider>
+          <main className="flex-1 p-4">
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <ProtectedRoute permission="view profile">
+                    <Home />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/contracts"
+                element={
+                  <ProtectedRoute permission="view contracts">
+                    <ContractsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route path="/forbidden" element={<Forbidden />} />
+            </Routes>
+          </main>
+        </div>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/components/auth/AuthContext.jsx
+++ b/frontend/src/components/auth/AuthContext.jsx
@@ -122,7 +122,14 @@ const updateUserContext = (updatedUser) => {
   };
 
   const hasRole = (roleName) => roles.includes(roleName);
-  const hasPermission = (permName) => permissions.includes(permName);
+  const hasPermission = (permName) => {
+    if (!permName) return roles.includes('Admin');
+    return (
+      roles.includes('Admin') ||
+      permissions.includes(permName) ||
+      permissions.some((p) => p.endsWith(permName))
+    );
+  };
  const updatePermissions = (newPermissions) => {
   setPermissions(newPermissions);
   sessionStorage.setItem('permissions', JSON.stringify(newPermissions));

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -3,13 +3,16 @@ import { Navigate } from 'react-router-dom';
 import { AuthContext } from '@/components/auth/AuthContext';
 
 /**
- * @param {string} permission - e.g. "view contracts"
+ * @param {string|string[]} permission - required permission(s)
  * @param {ReactNode} children - component to render if allowed
  */
 const ProtectedRoute = ({ permission, children }) => {
   const { hasPermission } = useContext(AuthContext);
 
-  return hasPermission(permission) ? children : <Navigate to="/forbidden" replace />;
+  const required = Array.isArray(permission) ? permission : [permission];
+  const allowed = required.every((perm) => hasPermission(perm));
+
+  return allowed ? children : <Navigate to="/forbidden" replace />;
 };
 
 export default ProtectedRoute;

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -107,7 +107,7 @@ const adminItems: NavItem[] = [
 export function AppSidebar() {
   const { open } = useSidebar();
   const location = useLocation();
-  const { user, logout } = useAuth();
+  const { user, roles, hasPermission, logout } = useAuth();
   const { t } = useTranslation();
   const { isRTL } = useLanguage();
   const currentPath = location.pathname;
@@ -120,11 +120,6 @@ export function AppSidebar() {
     isActive 
       ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium" 
       : "hover:bg-sidebar-accent/50 text-sidebar-foreground hover:text-sidebar-accent-foreground";
-
-  const hasPermission = (permission?: string) => {
-    if (!permission) return false;
-    return user?.permissions.includes(permission) || user?.role === 'Admin';
-  };
 
   const toggleItem = (key: string) =>
     setOpenItems((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -154,7 +149,7 @@ export function AppSidebar() {
                   {user?.name}
                 </p>
                 <p className="text-xs text-sidebar-foreground/70 truncate">
-                  {user?.role}
+                  {roles[0]}
                 </p>
               </div>
             </div>
@@ -244,7 +239,7 @@ export function AppSidebar() {
         </SidebarGroup>
 
         {/* Admin Section */}
-        {user?.role === 'Admin' && (
+        {roles.includes('Admin') && (
           <SidebarGroup>
             <SidebarGroupLabel className="text-sidebar-foreground/70 px-4 py-2">
               {!collapsed && 'الإدارة'}


### PR DESCRIPTION
## Summary
- add flexible permission helper supporting admin override
- secure routes via reusable ProtectedRoute
- render sidebar items based on user roles and permissions
- wire application routing and sidebar with AuthProvider

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a1fab175288330802326c3ab666d1b