### PR TITLE
Improve responsive dashboard header, sidebar, and notifications

### DIFF
--- a/frontend/src/components/common/DropdownNotifications.jsx
+++ b/frontend/src/components/common/DropdownNotifications.jsx
@@ -1,10 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
-import { useNotifications } from '@/components/Notifications/NotificationContext';
+import { useNotifications } from '@/context/NotificationContext';
 import IconButton from './iconButton';
 import { markAsRead as apiMarkAsRead } from '@/services/api/notifications';
 
-export default function DropdownNotifications() {
+export default function DropdownNotifications({ isRTL }) {
   const { notifications, hasNew, markRead, markAllAsRead } = useNotifications();
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
@@ -24,51 +24,59 @@ export default function DropdownNotifications() {
   };
 
   return (
-    <div className="relative" dir="rtl" ref={ref}>
-      <IconButton onClick={() => setOpen(o => !o)} active={open}>
+    <div className="relative" dir={isRTL ? 'rtl' : 'ltr'} ref={ref}>
+      <IconButton onClick={() => setOpen((o) => !o)} active={open}>
         <Bell className="w-6 h-6" />
-        {hasNew && <span className="absolute top-0 left-0 w-2.5 h-2.5 bg-red-500 rounded-full animate-ping" />}
+        {hasNew && (
+          <span
+            className={`absolute top-0 ${isRTL ? 'left-0' : 'right-0'} w-2.5 h-2.5 bg-red-500 rounded-full animate-ping`}
+          />
+        )}
       </IconButton>
 
-{open && (
-  <div
-    className={`
-      sm:absolute fixed sm:left-0 top-[72px] left-1/2 transform -translate-x-1/2
+      {open && (
+        <div
+          className={`
+      sm:absolute fixed ${isRTL ? 'sm:right-0' : 'sm:left-0'} top-[72px] left-1/2 transform -translate-x-1/2
       z-50 w-[90vw] max-w-sm sm:w-80 mt-2
       bg-white dark:bg-gray-800 rounded-xl shadow-lg ring-1 ring-black ring-opacity-5
     `}
-  >
-    <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-600 flex justify-between">
-      <span className="text-sm font-semibold dark:text-gray-100">الإشعارات</span>
-      {notifications.length > 0 && (
-        <button
-          className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-          onClick={markAllAsRead}
         >
-          تعيين الكل كمقروء
-        </button>
-      )}
-    </div>
-    <ul className="max-h-80 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
-      {notifications.length === 0 ? (
-        <li className="p-4 text-center text-sm dark:text-gray-400">لا توجد إشعارات</li>
-      ) : notifications.map(n => (
-        <li
-          key={n.id}
-          onClick={() => onClickNotif(n)}
-          className={`p-4 cursor-pointer transition hover:bg-gray-50 dark:hover:bg-gray-700 ${!n.read ? 'bg-emerald-50 dark:bg-emerald-900/30' : ''}`}
-        >
-          <div className="text-sm font-medium dark:text-white">{n.icon} {n.title}</div>
-          <div className="text-xs text-gray-600 dark:text-gray-400">{n.message}</div>
-          <div className="text-xs text-gray-400 mt-1">
-            {new Intl.DateTimeFormat('ar-EG',{dateStyle:'short',timeStyle:'short'}).format(new Date(n.created_at))}
+          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-600 flex justify-between">
+            <span className="text-sm font-semibold dark:text-gray-100">الإشعارات</span>
+            {notifications.length > 0 && (
+              <button
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                onClick={markAllAsRead}
+              >
+                تعيين الكل كمقروء
+              </button>
+            )}
           </div>
-        </li>
-      ))}
-    </ul>
-  </div>
-)}
-
+          <ul className="max-h-80 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
+            {notifications.length === 0 ? (
+              <li className="p-4 text-center text-sm dark:text-gray-400">لا توجد إشعارات</li>
+            ) : (
+              notifications.map((n) => (
+                <li
+                  key={n.id}
+                  onClick={() => onClickNotif(n)}
+                  className={`p-4 cursor-pointer transition hover:bg-gray-50 dark:hover:bg-gray-700 ${!n.read ? 'bg-emerald-50 dark:bg-emerald-900/30' : ''}`}
+                >
+                  <div className="text-sm font-medium dark:text-white">{n.icon} {n.title}</div>
+                  <div className="text-xs text-gray-600 dark:text-gray-400">{n.message}</div>
+                  <div className="text-xs text-gray-400 mt-1">
+                    {new Intl.DateTimeFormat(isRTL ? 'ar-EG' : 'en-US', {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    }).format(new Date(n.created_at))}
+                  </div>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -7,49 +7,42 @@ import { Input } from '@/components/ui/input';
 import { LanguageToggle } from '@/components/common/LanguageToggle';
 import { ThemeToggle } from '@/components/common/ThemeToggle';
 import ProfileMenu from '@/components/common/ProfileMenu';
+import DropdownNotifications from '@/components/common/DropdownNotifications';
 import { useLanguage } from '@/context/LanguageContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import EchoListener from '@/context/EchoListener';
 import AdminListener from '@/context/AdminListener';
-import { NotificationProvider } from '@/context/NotificationContext'; // Import NotificationProvider
+import { NotificationProvider } from '@/context/NotificationContext';
+import logoLight from '@/assets/images/logo-green.png';
+import logoDark from '@/assets/images/logo-white.png';
 
 const AppLayout = ({ children }) => {
   const { isRTL } = useLanguage();
   const isMobile = useIsMobile();
-  const [isSidebarOpen, setSidebarOpen] = useState(!isMobile);
+  const [isSidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
-    setSidebarOpen(!isMobile);
+    // Always start collapsed; hide completely on mobile
+    setSidebarOpen(false);
   }, [isMobile]);
 
   const toggleSidebar = () => setSidebarOpen((o) => !o);
   const closeSidebar = () => setSidebarOpen(false);
 
-  const marginClass = !isMobile
+  const contentMargin = !isMobile
     ? isSidebarOpen
       ? isRTL
         ? 'mr-64'
         : 'ml-64'
       : isRTL
-      ? 'mr-16'
-      : 'ml-16'
+        ? 'mr-16'
+        : 'ml-16'
     : '';
 
   return (
       <NotificationProvider>  
   
     <div dir={isRTL ? 'rtl' : 'ltr'}>
-      {!isSidebarOpen && isMobile && (
-        <button
-          onClick={toggleSidebar}
-          className={`fixed top-1/2 -translate-y-1/2 z-40 p-2 rounded bg-primary text-primary-foreground ${
-            isRTL ? 'right-0' : 'left-0'
-          }`}
-        >
-          <Menu className="h-5 w-5" />
-        </button>
-      )}
-
       <AppSidebar
         isOpen={isSidebarOpen}
         toggleSidebar={toggleSidebar}
@@ -57,28 +50,33 @@ const AppLayout = ({ children }) => {
         isMobile={isMobile}
         isRTL={isRTL}
       />
-
-      <div className={`flex flex-col min-h-screen transition-all duration-300 ${marginClass}`}>
+      <div className="flex flex-col min-h-screen">
         {/* Header */}
         <motion.header
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="h-16 border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-30 flex items-center justify-between px-6"
+          className="w-full h-16 border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-30 flex items-center justify-between px-6"
         >
-          <div className="flex items-center space-x-4 space-x-reverse">
-            {!isMobile && (
-              <button onClick={toggleSidebar} className="p-2 rounded hover:bg-muted">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center">
+              <img src={logoLight} alt="logo" className="h-8 dark:hidden" />
+              <img src={logoDark} alt="logo" className="h-8 hidden dark:block" />
+            </div>
+            {isMobile && (
+              <button onClick={toggleSidebar} className="p-2 rounded md:hidden hover:bg-muted">
                 <Menu className="h-5 w-5" />
               </button>
             )}
-            <h1 className="text-xl font-semibold text-foreground">منصة المدار</h1>
-            <div className="relative hidden md:block">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input placeholder="البحث..." className="pl-10 w-64 focus-ring" />
-            </div>
+            {!isMobile && (
+              <div className="relative hidden md:block">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input placeholder="البحث..." className="pl-10 w-64 focus-ring" />
+              </div>
+            )}
           </div>
 
-          <div className="flex items-center space-x-2 space-x-reverse">
+          <div className="flex items-center gap-2">
+            <DropdownNotifications isRTL={isRTL} />
             <LanguageToggle />
             <ThemeToggle />
             <ProfileMenu />
@@ -90,10 +88,10 @@ const AppLayout = ({ children }) => {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.1 }}
-          className="flex-1 overflow-auto bg-background"
+          className={`flex-1 overflow-auto bg-background transition-all duration-300 ${contentMargin}`}
         >
-                 <AdminListener />
-        <EchoListener />
+          <AdminListener />
+          <EchoListener />
           <div className="p-6">{children}</div>
         </motion.div>
       </div>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -73,10 +73,15 @@ export default function AppSidebar({
     : 'translate-x-0';
   const width = isMobile ? 'w-64' : isOpen ? 'w-64' : 'w-16';
 
+  const renderIcon = (icon) =>
+    React.cloneElement(icon, {
+      className: 'transition-transform group-hover:scale-110',
+    });
+
   return (
     <aside
       dir={isRTL ? 'rtl' : 'ltr'}
-      className={`fixed top-0 z-40 h-full ${side} ${width} ${translate} flex flex-col bg-text-sidebar-foreground transition-all duration-300`}
+      className={`fixed top-0 z-40 h-full ${side} ${width} ${translate} flex flex-col bg-sidebar text-sidebar-foreground shadow-lg transition-all duration-300`}
     >
       <div className={`flex items-center ${isOpen ? 'justify-between' : 'justify-center'} p-4`}>
         {isOpen && <span className="font-bold">Almadar</span>}
@@ -97,27 +102,29 @@ export default function AppSidebar({
               <NavLink
                 to={item.to}
                 onClick={isMobile ? closeSidebar : undefined}
+                title={item.label}
                 className={({ isActive }) =>
-                  `flex items-center gap-3 rounded-md p-2 transition-colors ${
+                  `group flex items-center gap-3 rounded-md p-2 transition-all ${
                     isActive
                       ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
                       : 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
                   } ${!isOpen && !isMobile ? 'justify-center' : ''}`
                 }
               >
-                {item.icon}
+                {renderIcon(item.icon)}
                 {(isOpen || isMobile) && <span className="flex-1 truncate">{item.label}</span>}
               </NavLink>
             ) : (
               <button
                 onClick={() => handleSectionClick(item.id, !!item.children)}
-                className={`flex w-full items-center gap-3 rounded-md p-2 transition-colors ${
+                title={item.label}
+                className={`group flex w-full items-center gap-3 rounded-md p-2 transition-all ${
                   activeSection === item.id
                     ? 'bg-sidebar-accent text-sidebar-accent-foreground font-medium'
                     : 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
                 } ${!isOpen && !isMobile ? 'justify-center' : ''}`}
               >
-                {item.icon}
+                {renderIcon(item.icon)}
                 {(isOpen || isMobile) && <span className="flex-1 truncate">{item.label}</span>}
                 {item.children && (isOpen || isMobile) && (
                   <ChevronRight
@@ -136,15 +143,16 @@ export default function AppSidebar({
                     key={child.id}
                     to={child.to}
                     onClick={isMobile ? closeSidebar : undefined}
+                    title={child.label}
                     className={({ isActive }) =>
-                      `flex items-center gap-2 rounded-md px-4 py-2 text-sm transition-colors ${
+                      `group flex items-center gap-2 rounded-md px-4 py-2 text-sm transition-all ${
                         isActive
                           ? 'bg-sidebar-accent text-sidebar-accent-foreground'
                           : 'hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground'
                       }`
                     }
                   >
-                    {child.icon}
+                    {renderIcon(child.icon)}
                     <span className="truncate">{child.label}</span>
                   </NavLink>
                 ))}


### PR DESCRIPTION
## Summary
- keep top header full width with language-aware logo placement and mobile-only sidebar toggle
- refine sidebar with collapsed icon layout, dynamic Tailwind colors, and animated hover styles
- integrate notification dropdown respecting RTL/LTR and functioning across screen sizes

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2770e53b48330b18ec45d75ba52e5