### PR TITLE
feat: add comprehensive theme and style guide

### DIFF
--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -1,0 +1,70 @@
+# Application Style Guide
+
+This guide defines the design tokens and components used across the application.
+It supports light and dark modes using CSS variables. All values are provided in
+HSL notation and exposed through Tailwind classes.
+
+## Color Palette
+
+### Light Mode
+| Token | HSL | Description |
+|------|-----|-------------|
+| `--background` | `210 20% 98%` | App background |
+| `--text-title` | `222 47% 11%` | Heading text |
+| `--text-body` | `215 20% 25%` | Body text |
+| `--text-muted` | `215 16% 52%` | Muted text and placeholders |
+| `--primary` | `222 83% 55%` | Primary actions & links |
+| `--secondary` | `262 83% 58%` | Secondary actions |
+| `--accent` | `164 60% 45%` | Accent highlights |
+| `--success` | `142 70% 45%` | Success state |
+| `--warning` | `38 92% 50%` | Warning state |
+| `--destructive` | `0 72% 50%` | Error state |
+| `--info` | `199 90% 48%` | Informational state |
+
+### Dark Mode
+| Token | HSL | Description |
+|------|-----|-------------|
+| `--background` | `215 40% 13%` | App background |
+| `--text-title` | `210 40% 98%` | Heading text |
+| `--text-body` | `214 32% 85%` | Body text |
+| `--text-muted` | `215 20% 65%` | Muted text and placeholders |
+| `--primary` | `222 83% 70%` | Primary actions & links |
+| `--secondary` | `262 83% 70%` | Secondary actions |
+| `--accent` | `164 65% 60%` | Accent highlights |
+| `--success` | `142 70% 55%` | Success state |
+| `--warning` | `38 92% 60%` | Warning state |
+| `--destructive` | `0 72% 60%` | Error state |
+| `--info` | `199 90% 60%` | Informational state |
+
+## Typography
+- `--font-heading`: Roboto, Open Sans, sans-serif
+- `--font-body`: Roboto, Open Sans, sans-serif
+
+## UI Components
+The following utility classes are available and adapt automatically to the
+current color mode:
+
+| Class | Purpose |
+|-------|---------|
+| `.btn` | Base button styles |
+| `.btn-primary` | Primary button variant |
+| `.btn-secondary` | Secondary button variant |
+| `.btn-accent` | Accent button variant |
+| `.btn-outline` | Outline button variant |
+| `.input` | Text input fields |
+| `.card` | Card and container surfaces |
+| `.navbar` | Application navigation bar |
+| `.modal` | Modal dialog container |
+| `.tooltip` | Tooltip body |
+| `.link` | Interactive link style |
+
+## Gradients & Effects
+- `bg-gradient-primary` – gradient from primary to secondary
+- `bg-gradient-card` – subtle card background gradient
+- `shadow-glow` – soft glow used on interactive elements
+
+## Usage
+All design tokens are available as CSS variables and in Tailwind through the
+configured color names (e.g. `text-title`, `bg-card`, `shadow-glow`). Components
+are built with Tailwind's `@apply` directive for consistency.
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,160 +6,176 @@
 
 @layer base {
   :root {
-    /* Core Colors - Day Mode Palette */
-    --background: 0 0% 96%;
-    --foreground: 240 5% 18%;
+    /* Light mode palette */
+    --background: 210 20% 98%;
+    --foreground: 215 20% 25%;
 
-    /* Card & Surface Colors */
+    /* Text */
+    --text-title: 222 47% 11%;
+    --text-body: 215 20% 25%;
+    --text-muted: 215 16% 52%;
+
+    /* Surfaces */
     --card: 0 0% 100%;
-    --card-foreground: 240 5% 18%;
-    --card-hover: 0 0% 94%;
-
-    /* Popover Colors */
+    --card-foreground: var(--text-body);
+    --card-hover: 210 20% 96%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 5% 18%;
+    --popover-foreground: var(--text-body);
 
-    /* Primary Brand Colors */
-    --primary: 210 64% 78%;
-    --primary-foreground: 240 5% 18%;
-    --primary-hover: 210 64% 70%;
-    --primary-light: 210 64% 85%;
+    /* Brand colors */
+    --primary: 222 83% 55%;
+    --primary-foreground: 210 40% 98%;
+    --primary-hover: 222 83% 47%;
+    --primary-active: 222 83% 40%;
+    --primary-light: 222 83% 60%;
 
-    /* CSS color tokens for Tailwind config */
+    --secondary: 262 83% 58%;
+    --secondary-foreground: 0 0% 100%;
+    --secondary-hover: 262 83% 52%;
+    --secondary-active: 262 83% 45%;
+
+    --accent: 164 60% 45%;
+    --accent-foreground: 0 0% 100%;
+    --accent-hover: 164 60% 40%;
+    --accent-active: 164 60% 35%;
+
+    /* Muted */
+    --muted: 210 16% 92%;
+    --muted-foreground: var(--text-muted);
+
+    /* Status */
+    --destructive: 0 72% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --success: 142 70% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 222 47% 11%;
+    --info: 199 90% 48%;
+    --info-foreground: 210 40% 98%;
+
+    /* Border & inputs */
+    --border: 210 16% 87%;
+    --input: 0 0% 100%;
+    --ring: 222 83% 55%;
+    --input-focus: var(--ring);
+
+    /* Gradients & shadows */
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--secondary)) 100%);
+    --gradient-secondary: linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--card-hover)) 100%);
+    --gradient-hero: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--secondary)) 50%, hsl(var(--accent)) 100%);
+    --gradient-card: linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--card-hover)) 100%);
+
+    --shadow-sm: 0 1px 3px hsla(222, 47%, 11%, 0.05);
+    --shadow-md: 0 4px 12px hsla(222, 47%, 11%, 0.1);
+    --shadow-lg: 0 10px 30px hsla(222, 47%, 11%, 0.15);
+    --shadow-xl: 0 20px 40px hsla(222, 47%, 11%, 0.2);
+    --shadow-glow: 0 0 15px hsla(222, 83%, 55%, 0.4);
+
+    /* Sidebar */
+    --sidebar-background: 222 47% 11%;
+    --sidebar-foreground: 210 40% 98%;
+    --sidebar-primary: 222 83% 55%;
+    --sidebar-primary-foreground: 210 40% 98%;
+    --sidebar-accent: 262 83% 58%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 222 47% 20%;
+    --sidebar-ring: 222 83% 55%;
+
+    /* Transitions & typography */
+    --transition-smooth: all 0.3s ease-in-out;
+    --transition-bounce: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    --font-heading: 'Roboto', 'Open Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-body: 'Roboto', 'Open Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+    --radius: 0.5rem;
+
+    /* Tokens */
     --primary-color: hsl(var(--primary));
     --secondary-color: hsl(var(--secondary));
     --accent-color: hsl(var(--accent));
     --background-color: hsl(var(--background));
-    
-    /* Secondary & Accent Colors */
-    --secondary: 5 100% 69%;
-    --secondary-foreground: 0 0% 100%;
-    --secondary-hover: 5 100% 60%;
-    
-    /* Muted Colors */
-    --muted: 0 0% 90%;
-    --muted-foreground: 240 5% 40%;
-    
-    /* Accent Colors */
-    --accent: 167 48% 77%;
-    --accent-foreground: 240 5% 18%;
-    --accent-hover: 167 48% 70%;
-    
-    /* Status Colors */
-    --destructive: 0 75% 55%;
-    --destructive-foreground: 0 0% 98%;
-    --success: 142 70% 45%;
-    --success-foreground: 0 0% 98%;
-    --warning: 51 100% 50%;
-    --warning-foreground: 240 5% 18%;
-    
-    /* Border & Input */
-    --border: 0 0% 85%;
-    --input: 0 0% 90%;
-    --input-focus: 210 64% 50%;
-    --ring: 210 64% 50%;
-    
-    /* Gradients */
-    --gradient-primary: linear-gradient(135deg, hsl(218, 35%, 25%) 0%, hsl(218, 40%, 35%) 100%);
-    --gradient-secondary: linear-gradient(135deg, hsl(210, 25%, 94%) 0%, hsl(214, 30%, 90%) 100%);
-    --gradient-hero: linear-gradient(135deg, hsl(218, 35%, 25%) 0%, hsl(218, 30%, 30%) 50%, hsl(214, 25%, 35%) 100%);
-    --gradient-card: linear-gradient(135deg, hsla(0, 0%, 100%, 0.9) 0%, hsla(210, 15%, 98%, 0.8) 100%);
-    
-    /* Shadows */
-    --shadow-sm: 0 1px 3px hsla(218, 25%, 15%, 0.08);
-    --shadow-md: 0 4px 12px hsla(218, 25%, 15%, 0.12);
-    --shadow-lg: 0 10px 30px hsla(218, 25%, 15%, 0.15);
-    --shadow-xl: 0 20px 40px hsla(218, 25%, 15%, 0.20);
-    --shadow-glow: 0 0 30px hsla(218, 35%, 25%, 0.15);
-    
-    /* Sidebar */
-    --sidebar-background: 218 30% 25%;
-    --sidebar-foreground: 210 15% 85%;
-    --sidebar-primary: 218 35% 25%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 218 25% 30%;
-    --sidebar-accent-foreground: 210 15% 90%;
-    --sidebar-border: 218 20% 35%;
-    --sidebar-ring: 214 25% 88%;
-    
-    /* Animations */
-    --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    --transition-bounce: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    
-    /* Typography */
-    --font-heading: 'Roboto', 'Open Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    --font-body: 'Roboto', 'Open Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    
-    --radius: 0.75rem;
   }
 
   .dark {
-    /* Dark Theme Colors */
-    --background: 240 2% 18%;
-    --foreground: 0 0% 88%;
+    /* Dark mode palette */
+    --background: 215 40% 13%;
+    --foreground: 214 32% 85%;
 
-    --card: 240 2% 23%;
-    --card-foreground: 0 0% 88%;
-    --card-hover: 240 2% 26%;
+    /* Text */
+    --text-title: 210 40% 98%;
+    --text-body: 214 32% 85%;
+    --text-muted: 215 20% 65%;
 
-    --popover: 240 2% 23%;
-    --popover-foreground: 0 0% 88%;
+    /* Surfaces */
+    --card: 215 28% 17%;
+    --card-foreground: var(--text-body);
+    --card-hover: 215 28% 20%;
+    --popover: 215 28% 17%;
+    --popover-foreground: var(--text-body);
 
-    --primary: 240 22% 15%;
-    --primary-foreground: 0 0% 88%;
-    --primary-hover: 240 22% 20%;
-    --primary-light: 240 22% 25%;
+    /* Brand colors */
+    --primary: 222 83% 70%;
+    --primary-foreground: 222 47% 11%;
+    --primary-hover: 222 83% 75%;
+    --primary-active: 222 83% 65%;
+    --primary-light: 222 83% 80%;
 
-    /* CSS color tokens for Tailwind config */
+    --secondary: 262 83% 70%;
+    --secondary-foreground: 222 47% 11%;
+    --secondary-hover: 262 83% 75%;
+    --secondary-active: 262 83% 65%;
+
+    --accent: 164 65% 60%;
+    --accent-foreground: 222 47% 11%;
+    --accent-hover: 164 65% 65%;
+    --accent-active: 164 65% 55%;
+
+    /* Muted */
+    --muted: 215 28% 25%;
+    --muted-foreground: var(--text-muted);
+
+    /* Status */
+    --destructive: 0 72% 60%;
+    --destructive-foreground: 222 47% 11%;
+    --success: 142 70% 55%;
+    --success-foreground: 222 47% 11%;
+    --warning: 38 92% 60%;
+    --warning-foreground: 222 47% 11%;
+    --info: 199 90% 60%;
+    --info-foreground: 222 47% 11%;
+
+    /* Border & inputs */
+    --border: 215 28% 25%;
+    --input: 215 28% 20%;
+    --ring: 222 83% 70%;
+    --input-focus: var(--ring);
+
+    /* Gradients & shadows */
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--secondary)) 100%);
+    --gradient-secondary: linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--card-hover)) 100%);
+    --gradient-hero: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--secondary)) 50%, hsl(var(--accent)) 100%);
+    --gradient-card: linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--card-hover)) 100%);
+
+    --shadow-sm: 0 1px 3px hsla(0, 0%, 0%, 0.4);
+    --shadow-md: 0 4px 12px hsla(0, 0%, 0%, 0.5);
+    --shadow-lg: 0 10px 30px hsla(0, 0%, 0%, 0.6);
+    --shadow-xl: 0 20px 40px hsla(0, 0%, 0%, 0.7);
+    --shadow-glow: 0 0 20px hsla(222, 83%, 70%, 0.4);
+
+    /* Sidebar */
+    --sidebar-background: 215 40% 13%;
+    --sidebar-foreground: 214 32% 85%;
+    --sidebar-primary: 222 83% 70%;
+    --sidebar-primary-foreground: 222 47% 11%;
+    --sidebar-accent: 262 83% 70%;
+    --sidebar-accent-foreground: 222 47% 11%;
+    --sidebar-border: 215 28% 25%;
+    --sidebar-ring: 222 83% 70%;
+
+    /* Tokens */
     --primary-color: hsl(var(--primary));
     --secondary-color: hsl(var(--secondary));
     --accent-color: hsl(var(--accent));
     --background-color: hsl(var(--background));
-    
-    --secondary: 180 100% 15%;
-    --secondary-foreground: 0 0% 90%;
-    --secondary-hover: 180 100% 20%;
-    
-    --muted: 240 2% 23%;
-    --muted-foreground: 0 0% 70%;
-    
-    --accent: 240 2% 23%;
-    --accent-foreground: 0 0% 88%;
-    --accent-hover: 240 2% 30%;
-    
-    --destructive: 0 65% 50%;
-    --destructive-foreground: 0 0% 98%;
-    --success: 142 65% 45%;
-    --success-foreground: 0 0% 98%;
-    --warning: 51 100% 50%;
-    --warning-foreground: 240 5% 18%;
-    
-    --border: 240 2% 25%;
-    --input: 240 2% 25%;
-    --input-focus: 210 64% 60%;
-    --ring: 210 64% 60%;
-    
-    /* Dark Gradients */
-    --gradient-primary: linear-gradient(135deg, hsl(210, 64%, 78%) 0%, hsl(210, 64%, 70%) 100%);
-    --gradient-secondary: linear-gradient(135deg, hsl(240, 2%, 23%) 0%, hsl(240, 2%, 30%) 100%);
-    --gradient-hero: linear-gradient(135deg, hsl(240, 2%, 18%) 0%, hsl(240, 2%, 23%) 50%, hsl(210, 64%, 78%) 100%);
-    --gradient-card: linear-gradient(135deg, hsla(240, 2%, 23%, 0.9) 0%, hsla(240, 2%, 26%, 0.8) 100%);
-    
-    /* Dark Shadows */
-    --shadow-sm: 0 1px 3px hsla(0, 0%, 0%, 0.3);
-    --shadow-md: 0 4px 12px hsla(0, 0%, 0%, 0.4);
-    --shadow-lg: 0 10px 30px hsla(0, 0%, 0%, 0.5);
-    --shadow-xl: 0 20px 40px hsla(0, 0%, 0%, 0.6);
-    --shadow-glow: 0 0 30px hsla(210, 64%, 78%, 0.2);
-    
-    --sidebar-background: 240 2% 18%;
-    --sidebar-foreground: 0 0% 88%;
-    --sidebar-primary: 240 22% 15%;
-    --sidebar-primary-foreground: 0 0% 88%;
-    --sidebar-accent: 240 2% 23%;
-    --sidebar-accent-foreground: 0 0% 88%;
-    --sidebar-border: 240 2% 25%;
-    --sidebar-ring: 210 64% 60%;
   }
 }
 
@@ -275,6 +291,52 @@
   /* Focus Ring */
   .focus-ring {
     @apply focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2;
+  }
+
+  /* Base button styles and variants */
+  .btn {
+    @apply inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none;
+  }
+  .btn-primary {
+    @apply bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active hover:shadow-glow;
+  }
+  .btn-secondary {
+    @apply bg-secondary text-secondary-foreground hover:bg-secondary-hover active:bg-secondary-active hover:shadow-glow;
+  }
+  .btn-accent {
+    @apply bg-accent text-accent-foreground hover:bg-accent-hover active:bg-accent-active hover:shadow-glow;
+  }
+  .btn-outline {
+    @apply border border-border bg-transparent text-body hover:bg-muted hover:text-title;
+  }
+
+  /* Form inputs */
+  .input {
+    @apply w-full rounded-md border border-border bg-input px-3 py-2 text-body placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring transition-colors;
+  }
+
+  /* Cards and containers */
+  .card {
+    @apply bg-card text-card-foreground rounded-lg shadow-sm hover:shadow-md transition-shadow;
+  }
+
+  /* Navigation bar */
+  .navbar {
+    @apply bg-background text-foreground shadow-sm;
+  }
+
+  /* Modals & popovers */
+  .modal {
+    @apply bg-popover text-popover-foreground rounded-lg shadow-lg p-6;
+  }
+
+  .tooltip {
+    @apply bg-popover text-popover-foreground text-sm rounded-md px-2 py-1 shadow-md;
+  }
+
+  /* Links */
+  .link {
+    @apply text-primary hover:text-primary-hover underline-offset-4 hover:underline transition-colors;
   }
   
   /* Premium animations */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,9 +11,11 @@ module.exports = {
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
+                                ring: 'hsl(var(--ring))',
                                 background: 'var(--background-color)',
                                 foreground: 'hsl(var(--foreground))',
+                                title: 'hsl(var(--text-title))',
+                                body: 'hsl(var(--text-body))',
                                 primary: {
                                         DEFAULT: 'var(--primary-color)',
                                         foreground: 'hsl(var(--primary-foreground))',
@@ -33,14 +35,18 @@ module.exports = {
 					DEFAULT: 'hsl(var(--success))',
 					foreground: 'hsl(var(--success-foreground))'
 				},
-				warning: {
-					DEFAULT: 'hsl(var(--warning))',
-					foreground: 'hsl(var(--warning-foreground))'
-				},
-				muted: {
-					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))'
-				},
+                                warning: {
+                                        DEFAULT: 'hsl(var(--warning))',
+                                        foreground: 'hsl(var(--warning-foreground))'
+                                },
+                                info: {
+                                        DEFAULT: 'hsl(var(--info))',
+                                        foreground: 'hsl(var(--info-foreground))'
+                                },
+                                muted: {
+                                        DEFAULT: 'hsl(var(--muted))',
+                                        foreground: 'hsl(var(--muted-foreground))'
+                                },
                                 accent: {
                                         DEFAULT: 'var(--accent-color)',
                                         foreground: 'hsl(var(--accent-foreground))',


### PR DESCRIPTION
## Summary
- expand CSS variables for light and dark palettes, including text, status, and interactive colors
- add Tailwind color tokens and component utilities for buttons, inputs, cards, navigation, modals, and tooltips
- document the design system in STYLE_GUIDE.md

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a28db992a88330b97c95416ad02340