### PR TITLE
Animate gradients and gate table actions with permissions

### DIFF
--- a/frontend/src/components/common/TableComponent.jsx
+++ b/frontend/src/components/common/TableComponent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useContext } from 'react';
 import { Edit, Eye, Trash, ChevronUp, ChevronDown } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import API_CONFIG from '../../config/config';
-import { AuthContext } from '@/context/AuthContext';;
+import { AuthContext } from '@/context/AuthContext';
 
 export default function TableComponent({
   data = [],
@@ -78,6 +78,9 @@ export default function TableComponent({
     }
   };
 
+  const showActions =
+    (onView && can('view')) || (onEdit && can('edit')) || (onDelete && can('delete'));
+
   return (
     <div className="bg-white dark:bg-zinc-900 p-4 rounded-xl shadow-lg border dark:border-zinc-700 transition-all">
       {/* Toolbar */}
@@ -126,14 +129,14 @@ export default function TableComponent({
                   </div>
                 </th>
               ))}
-              {(onView || onEdit || onDelete) && <th className="p-3">إجراءات</th>}
+              {showActions && <th className="p-3">إجراءات</th>}
             </tr>
           </thead>
           <tbody className="divide-y dark:divide-zinc-800">
             {paginatedData.map((row) => (
               <React.Fragment key={row.id}>
                 <tr
-                  className="hover:bg-gold-light/30 dark:hover:bg-greenic-light/10 transition cursor-pointer"
+                  className="hover:bg-gold-light/30 dark:hover:bg-greenic-light/10 transition cursor-pointer animate-fade-in-up"
                   onClick={() => onRowClick?.(row)}
                 >
                   <td className="p-2 text-center">
@@ -164,23 +167,25 @@ export default function TableComponent({
                       )}
                     </td>
                   ))}
-                  <td className="p-2 space-x-1 text-center">
-                    {onView && (
-                      <button onClick={() => onView(row)} className="text-blue-600 hover:text-blue-800">
-                        <Eye size={16} />
-                      </button>
-                    )}
-                    {onEdit && (
-                      <button onClick={() => onEdit(row)} className="text-purple-600 hover:text-purple-800">
-                        <Edit size={16} />
-                      </button>
-                    )}
-                    {onDelete && (
-                      <button onClick={() => onDelete(row)} className="text-red-600 hover:text-red-800">
-                        <Trash size={16} />
-                      </button>
-                    )}
-                  </td>
+                  {showActions && (
+                    <td className="p-2 space-x-1 text-center">
+                      {onView && can('view') && (
+                        <button onClick={() => onView(row)} className="text-blue-600 hover:text-blue-800">
+                          <Eye size={16} />
+                        </button>
+                      )}
+                      {onEdit && can('edit') && (
+                        <button onClick={() => onEdit(row)} className="text-purple-600 hover:text-purple-800">
+                          <Edit size={16} />
+                        </button>
+                      )}
+                      {onDelete && can('delete') && (
+                        <button onClick={() => onDelete(row)} className="text-red-600 hover:text-red-800">
+                          <Trash size={16} />
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
                 {expandedRowRenderer?.(row)}
               </React.Fragment>

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -55,17 +55,16 @@ const AppLayout = ({ children }) => {
   <motion.header
   initial={{ opacity: 0, y: -20 }}
   animate={{ opacity: 1, y: 0 }}
-  className="w-full h-16 border-b border-border 
-             bg-gradient-to-l 
-             from-[#69a52b] 
-             via-blue-400
-             to-blue-200
-             dark:bg-gradient-to-l 
-             dark:from-[#131b2a] 
+  className="w-full h-16 border-b border-border
+             bg-gradient-to-l
+             from-[#69a52b]
+             via-[#3aa8a0]
+             to-[#3b82f6]
+             dark:from-[#131b2a]
              dark:via-[#1b2f56]
              dark:to-[#171f37]
-             backdrop-blur-sm sticky top-0 z-30 
-             flex items-center justify-between px-6"
+             backdrop-blur-sm sticky top-0 z-30
+             flex items-center justify-between px-6 animate-gradient"
 >
 
             <div className="flex items-center">

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -81,14 +81,13 @@ export default function AppSidebar({
   return (
     <aside
       dir={isRTL ? 'rtl' : 'ltr'}
-      className={`fixed top-16 z-40 h-full ${side} ${width} ${translate} flex flex-col   bg-gradient-to-b 
-             from-[#69a52b] 
-             via-blue-[#69a52b]
-             to-blue-300
-             dark:bg-gradient-to-b 
-             dark:from-[#131b2a] 
+      className={`fixed top-16 z-40 h-full ${side} ${width} ${translate} flex flex-col bg-gradient-to-b
+             from-[#69a52b]
+             via-[#3aa8a0]
+             to-[#3b82f6]
+             dark:from-[#131b2a]
              dark:via-[#1b2f56]
-             dark:to-[#171f37] text-sidebar-foreground shadow-lg transition-all duration-300`}
+             dark:to-[#171f37] text-sidebar-foreground shadow-lg transition-all duration-300 animate-gradient`}
     >
       <div className={`flex items-center ${isOpen ? 'justify-between' : 'justify-center'} p-4`}>
         {isOpen && <span className="font-bold">Almadar</span>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -354,6 +354,12 @@
   .animate-scale-in {
     animation: scaleIn 0.4s ease-out forwards;
   }
+
+  /* Animated gradient backgrounds */
+  .animate-gradient {
+    background-size: 200% 200%;
+    animation: gradientShift 10s ease infinite;
+  }
   
   @keyframes fadeInUp {
     from {
@@ -385,6 +391,18 @@
     to {
       opacity: 1;
       transform: scale(1);
+    }
+  }
+
+  @keyframes gradientShift {
+    0% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0% 50%;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add animated gradient background for header and sidebar
- hide table action buttons unless user has matching permission
- introduce reusable gradient animation utility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c57f86348330bc3388f954476725