### PR TITLE
Add user endpoint and refine React auth context

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -60,6 +60,20 @@ public function login(Request $request)
     ]);
 }
 
+    public function user(Request $request)
+    {
+        $user = $request->user();
+
+        $roles = $user->getRoleNames();
+        $permissions = $user->getAllPermissions()->pluck('name');
+
+        return response()->json([
+            'user' => $user,
+            'roles' => $roles,
+            'permissions' => $permissions,
+        ]);
+    }
+
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -39,6 +39,7 @@ Route::options('/{any}', function () {
 // Protected routes (requires authentication)
 Route::middleware('auth:sanctum')->group(function () {
 
+    Route::get('/user', [AuthController::class, 'user']);
     Route::post('/logout', [AuthController::class, 'logout']);
     
     // Contracts

--- a/frontend/src/components/auth/AuthContext.jsx
+++ b/frontend/src/components/auth/AuthContext.jsx
@@ -7,9 +7,7 @@ import React, {
 } from 'react';
 import AuthSpinner from '@/components/common/Spinners/AuthSpinner';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
 import { toast } from 'sonner';
-import API_CONFIG from '../../config/config';
 import api, { setOnUnauthorized } from '@/services/api/axiosConfig';
 
 // إنشاء السياق الافتراضي
@@ -75,17 +73,12 @@ export function AuthProvider({ children }) {
    */
   const login = async (email, password) => {
     try {
-      // استدعاء CSRF
-      await axios.get(`${API_CONFIG.baseURL}/sanctum/csrf-cookie`, {
-        withCredentials: true,
-      });
+      await api.get('/sanctum/csrf-cookie');
 
-      // إرسال بيانات الدخول
-      const resp = await axios.post(
-        `${API_CONFIG.baseURL}/api/login`,
+      const resp = await api.post(
+        '/api/login',
         { email, password },
         {
-          withCredentials: true,
           headers: { 'Content-Type': 'application/json' },
         }
       );


### PR DESCRIPTION
## Summary
- add `/user` API route returning authenticated user info
- expose user details with roles and permissions in Laravel AuthController
- streamline React AuthContext to use shared axios instance for login

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a906aefb64832887d5e3ad3adf2c3b