### PR TITLE
Add language-aware layout with responsive sidebar

### DIFF
--- a/frontend/src/components/dashboard/Header.jsx
+++ b/frontend/src/components/dashboard/Header.jsx
@@ -4,39 +4,40 @@ import UserMenu from '../common/DropdownProfile';
 import ThemeToggle from '../common/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
+import { useLanguage } from '@/context/LanguageContext';
 
-export default function Header({ isOpen,user, onToggleSidebar }) {
-  
+export default function Header({ isOpen, user, onToggleSidebar }) {
+  const { dir, toggleLanguage, lang } = useLanguage();
+
   return (
- 
-<nav
-  dir="rtl"
-  className={`
-    fixed top-0 left-0 right-0
-    transition-all duration-300
-    ${isOpen ? 'sm:mr-64' : 'sm:mr-16'}
-    py-3 px-6 flex justify-between items-center
-    bg-navy-light dark:bg-black
-    bg-gradient-to-l from-gold via-greenic/80 to-royal/80 
-    dark:bg-gradient-to-l dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
-    text-gray-900 dark:text-white
-    border-b border-gray-200 dark:border-navy-dark
-    shadow-md dark:shadow-[0_01px_#16b8f640]
-    z-20
-  `}
->
-  
-
-
+    <nav
+      dir={dir}
+      className={`
+        fixed top-0 left-0 right-0
+        transition-all duration-300
+        ${isOpen ? 'sm:mr-64' : 'sm:mr-16'}
+        py-3 px-6 flex justify-between items-center
+        bg-navy-light dark:bg-black
+        bg-gradient-to-l from-gold via-greenic/80 to-royal/80
+        dark:bg-gradient-to-l dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
+        text-gray-900 dark:text-white
+        border-b border-gray-200 dark:border-navy-dark
+        shadow-md dark:shadow-[0_01px_#16b8f640]
+        z-20
+      `}
+    >
       <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
         <Menu className="text-white dark:text-greenic h-5 w-5 hover:text-greenic-light" />
       </Button>
- 
+
       <div className="flex items-center gap-3">
-        <Notifications userId={user.id} align="right" />
+        <Button variant="ghost" size="icon" onClick={toggleLanguage}>
+          {lang === 'ar' ? 'EN' : 'AR'}
+        </Button>
+        <Notifications userId={user.id} align={dir === 'rtl' ? 'right' : 'left'} />
         <ThemeToggle />
         <div className="hidden sm:block w-px h-6 bg-border" />
-        <UserMenu align="left" />
+        <UserMenu align={dir === 'rtl' ? 'left' : 'right'} />
       </div>
     </nav>
   );

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect, lazy, Suspense } from 'react';
+import { useLocation } from 'react-router-dom';
+import ResponsiveLayout from '@/components/ResponsiveLayout';
+import { useMobileTheme } from '@/components/MobileThemeProvider';
+
+const Header = lazy(() => import('@/components/dashboard/Header'));
+const AppSidebar = lazy(() => import('./AppSidebar'));
+
+export default function AppLayout({ children, user }) {
+  const { isMobile, isStandalone, safeAreaInsets } = useMobileTheme();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (isMobile) setSidebarOpen(false);
+  }, [location.pathname, isMobile]);
+
+  const toggleSidebar = () => setSidebarOpen(prev => !prev);
+
+  const mainStyles = {
+    paddingTop: isMobile ? (isStandalone ? `${safeAreaInsets.top + 80}px` : '80px') : '112px',
+    paddingBottom: isStandalone && isMobile ? `${safeAreaInsets.bottom + 32}px` : '32px',
+    marginRight: !isMobile ? (sidebarOpen ? '260px' : '64px') : '0',
+    minHeight: isMobile ? 'calc(var(--vh, 1vh) * 100)' : '100vh'
+  };
+
+  return (
+    <ResponsiveLayout className="min-h-screen flex flex-col sm:flex-row relative">
+      <Suspense fallback={<div className="text-center p-4">جاري تحميل القائمة الجانبية...</div>}>
+        <AppSidebar
+          isOpen={sidebarOpen}
+          onToggle={toggleSidebar}
+          onLinkClick={() => isMobile && setSidebarOpen(false)}
+        />
+        {isMobile && sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 z-10"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+      </Suspense>
+      <div className="flex-1 flex flex-col transition-all duration-300">
+        <Suspense fallback={<div className="text-center p-4">جاري تحميل الرأس...</div>}>
+          <Header user={user} isOpen={sidebarOpen} onToggleSidebar={toggleSidebar} />
+        </Suspense>
+        <main
+          className={`
+            flex-1 px-4 sm:px-6 lg:px-8
+            bg-greenic-light/10 dark:bg-greenic-darker/20
+            transition-all duration-500
+            ${isMobile ? 'mobile-main' : 'desktop-main'}
+            ${isStandalone ? 'standalone-main' : ''}
+          `}
+          style={mainStyles}
+        >
+          {children}
+        </main>
+      </div>
+    </ResponsiveLayout>
+  );
+}

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '@/components/auth/AuthContext';
+import { useLanguage } from '@/context/LanguageContext';
 import { LogoArt, LogoPatren } from '../../assets/images';
 import {
   ContractsIcon, ConsultationsIcon, LawsuitsIcon, DashboardIcon,
@@ -10,8 +11,9 @@ import {
   Settings2, ListTree, UsersRound, UserCheck, ChevronRight
 } from 'lucide-react';
 
-export default function Sidebar({ isOpen, onToggle, onLinkClick }) {
+export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
   const { hasPermission } = useAuth();
+  const { t, dir } = useLanguage();
   const [activeSection, setActiveSection] = useState(null);
   const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth >= 1024);
 
@@ -24,37 +26,37 @@ export default function Sidebar({ isOpen, onToggle, onLinkClick }) {
   const logoSrc = isOpen ? LogoPatren : LogoArt;
 
   const navConfig = useMemo(() => [
-    { id: 'home', label: 'الرئيسية', to: '/', icon: <DashboardIcon size={20} /> },
+    { id: 'home', label: t('home'), to: '/', icon: <DashboardIcon size={20} /> },
     hasPermission('view contracts') && {
-      id: 'contracts', label: 'التعاقدات', to: '/contracts', icon: <ContractsIcon size={20} />
+      id: 'contracts', label: t('contracts'), to: '/contracts', icon: <ContractsIcon size={20} />
     },
     (hasPermission('view investigations') || hasPermission('view legaladvices') || hasPermission('view litigations')) && {
-      id: 'fatwa', label: 'الرأي والفتوى', icon: <ConsultationsIcon size={20} />, children: [
+      id: 'fatwa', label: t('fatwa'), icon: <ConsultationsIcon size={20} />, children: [
         hasPermission('view investigations') && {
-          id: 'investigations', label: 'التحقيقات', to: '/legal/investigations', icon: <LawsuitsIcon size={16} />
+          id: 'investigations', label: t('investigations'), to: '/legal/investigations', icon: <LawsuitsIcon size={16} />
         },
         hasPermission('view legaladvices') && {
-          id: 'legal-advices', label: 'المشورة القانونية', to: '/legal/legal-advices', icon: <LawBookIcon size={16} />
+          id: 'legal-advices', label: t('legalAdvices'), to: '/legal/legal-advices', icon: <LawBookIcon size={16} />
         },
         hasPermission('view litigations') && {
-          id: 'litigations', label: 'التقاضي', to: '/legal/litigations', icon: <CourtHouseIcon size={16} />
+          id: 'litigations', label: t('litigations'), to: '/legal/litigations', icon: <CourtHouseIcon size={16} />
         },
       ].filter(Boolean)
     },
     hasPermission('view managment-lists') && {
-      id: 'management', label: 'إدارة التطبيق', icon: <Settings2 size={20} />, children: [
-        { id: 'lists', label: 'القوائم', to: '/managment-lists', icon: <ListTree size={16} /> },
+      id: 'management', label: t('management'), icon: <Settings2 size={20} />, children: [
+        { id: 'lists', label: t('lists'), to: '/managment-lists', icon: <ListTree size={16} /> },
       ]
     },
     hasPermission('view users') && {
-      id: 'users', label: 'إدارة المستخدمين', icon: <UsersRound size={20} />, children: [
-        { id: 'users-list', label: 'المستخدمين', to: '/users', icon: <UserCheck size={16} /> },
+      id: 'users', label: t('users'), icon: <UsersRound size={20} />, children: [
+        { id: 'users-list', label: t('usersList'), to: '/users', icon: <UserCheck size={16} /> },
       ]
     },
     hasPermission('view archive') && {
-      id: 'archive', label: 'الأرشيف', to: '/archive', icon: <ArchiveIcon size={20} />
+      id: 'archive', label: t('archive'), to: '/archive', icon: <ArchiveIcon size={20} />
     },
-  ].filter(Boolean), [hasPermission]);
+  ].filter(Boolean), [hasPermission, t]);
 
   const handleSectionClick = (id, hasChildren) => {
     if (!isLargeScreen && !isOpen) onToggle();
@@ -63,12 +65,12 @@ export default function Sidebar({ isOpen, onToggle, onLinkClick }) {
 
   return (
     <aside
-      dir="rtl"
-      className={`fixed right-0 top-0 z-20 h-full bg-gold dark:bg-navy-darker
+      dir={dir}
+      className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0'} top-0 z-20 h-full bg-gold dark:bg-navy-darker
         bg-gradient-to-b from-gold via-greenic-dark/50 to-royal/80
         dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/40
         transition-all duration-300
-        ${isLargeScreen ? (isOpen ? 'w-64' : 'w-16') : (isOpen ? 'w-full mt-12' : 'translate-x-full')}
+        ${isLargeScreen ? (isOpen ? 'w-64' : 'w-16') : (isOpen ? 'w-full mt-12' : `${dir === 'rtl' ? 'translate-x-full' : '-translate-x-full'}`)}
       `}
     >
       <div className="flex items-center justify-center p-0 mt-6">
@@ -120,7 +122,7 @@ export default function Sidebar({ isOpen, onToggle, onLinkClick }) {
                 {item.children && (
                   <ChevronRight
                     className={`w-4 h-4 transform transition-transform duration-200
-                      ${activeSection === item.id ? 'rotate-90' : ''}`}
+                      ${activeSection === item.id ? (dir === 'rtl' ? 'rotate-90' : '-rotate-90') : ''}`}
                   />
                 )}
               </button>

--- a/frontend/src/context/LanguageContext.jsx
+++ b/frontend/src/context/LanguageContext.jsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const translations = {
+  ar: {
+    home: 'الرئيسية',
+    contracts: 'التعاقدات',
+    investigations: 'التحقيقات',
+    legalAdvices: 'المشورة القانونية',
+    litigations: 'التقاضي',
+    management: 'إدارة التطبيق',
+    lists: 'القوائم',
+    users: 'إدارة المستخدمين',
+    usersList: 'المستخدمين',
+    archive: 'الأرشيف',
+    fatwa: 'الرأي والفتوى'
+  },
+  en: {
+    home: 'Home',
+    contracts: 'Contracts',
+    investigations: 'Investigations',
+    legalAdvices: 'Legal Advices',
+    litigations: 'Litigations',
+    management: 'App Management',
+    lists: 'Lists',
+    users: 'Users Management',
+    usersList: 'Users',
+    archive: 'Archive',
+    fatwa: 'Fatwa'
+  }
+};
+
+const LanguageContext = createContext();
+
+export const LanguageProvider = ({ children }) => {
+  const [lang, setLang] = useState('ar');
+
+  useEffect(() => {
+    document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+  }, [lang]);
+
+  const toggleLanguage = () => setLang(prev => (prev === 'ar' ? 'en' : 'ar'));
+
+  const t = key => translations[lang][key] || key;
+  const dir = lang === 'ar' ? 'rtl' : 'ltr';
+
+  return (
+    <LanguageContext.Provider value={{ lang, dir, toggleLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,99 +1,50 @@
 import React, { useState, useEffect, useContext, lazy, Suspense } from 'react';
-import { useLocation } from "react-router-dom";
-   
-import AuthSpinner  from '@/components/common/Spinners/AuthSpinner';
+
+import AuthSpinner from '@/components/common/Spinners/AuthSpinner';
 import { AuthContext } from '@/components/auth/AuthContext';
-import { AnimatePresence } from 'framer-motion'; 
-import { MobileThemeProvider, useMobileTheme } from '@/components/MobileThemeProvider';
-import ResponsiveLayout from '@/components/ResponsiveLayout';
+import { AnimatePresence } from 'framer-motion';
+import { MobileThemeProvider } from '@/components/MobileThemeProvider';
 import { NotificationProvider } from '@/components/Notifications/NotificationContext';
 import { AppWithQuery } from '@/hooks/dataHooks';
+import { LanguageProvider } from '@/context/LanguageContext';
 
-const Header = lazy(() => import('@/components/dashboard/Header'));
-const Sidebar = lazy(() => import('@/components/dashboard/Sidebar'));
+const AppLayout = lazy(() => import('@/components/layout/AppLayout'));
 const AuthRoutes = lazy(() => import('@/components/layout/AuthRoutes'));
 const ForcePasswordChangeModal = lazy(() => import('@/components/auth/ForcePasswordChangeModal'));
 
 const DashboardContent = () => {
   const { user } = useContext(AuthContext);
-  const { isMobile, isStandalone, safeAreaInsets } = useMobileTheme();
 
   const [forcePasswordModal, setForcePasswordModal] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const location = useLocation(); 
 
   useEffect(() => {
     if (user && user.password_changed === 0) setForcePasswordModal(true);
   }, [user]);
-
-  useEffect(() => {
-    if (isMobile) setSidebarOpen(false);
-  }, [location.pathname, isMobile]);
-
-  const toggleSidebar = () => setSidebarOpen(prev => !prev);
-
-  const mainStyles = {
-    paddingTop: isMobile ? (isStandalone ? `${safeAreaInsets.top + 80}px` : '80px') : '112px',
-    paddingBottom: isStandalone && isMobile ? `${safeAreaInsets.bottom + 32}px` : '32px',
-    marginRight: !isMobile ? (sidebarOpen ? '260px' : '64px') : '0',
-    minHeight: isMobile ? 'calc(var(--vh, 1vh) * 100)' : '100vh'
-  };
-
   return (
-    <ResponsiveLayout className="min-h-screen flex flex-col sm:flex-row relative">
-       <Suspense fallback={<div className="text-center p-4">جاري تحميل القائمة الجانبية...</div>}>
-     <Sidebar
-        isOpen={sidebarOpen}
-        onToggle={toggleSidebar}
-        onLinkClick={() => isMobile && setSidebarOpen(false)}
-        userPermissions={user.permissions.map(p => p.name)}
-      />
-
-      {isMobile && sidebarOpen && (
-        <div 
-          className="fixed inset-0 bg-black/50 z-10" 
-          onClick={() => setSidebarOpen(false)} 
-        />
-      )}
+    <AppLayout user={user}>
+      <Suspense fallback={<AuthSpinner />}>
+        <AuthRoutes />
       </Suspense>
-      <div className="flex-1 flex flex-col transition-all duration-300">
-        <Suspense fallback={<AuthSpinner />}>
-          <Header user={user?.id} isOpen={sidebarOpen} onToggleSidebar={toggleSidebar} />
-        </Suspense>
-  <main 
-          className={`
-            flex-1 px-4 sm:px-6 lg:px-8 
-            bg-greenic-light/10 dark:bg-greenic-darker/20 
-            transition-all duration-500
-            ${isMobile ? 'mobile-main' : 'desktop-main'}
-            ${isStandalone ? 'standalone-main' : ''}
-          `}
-          style={mainStyles}
-        >
-      <Suspense fallback={<AuthSpinner/>}>
-            <AuthRoutes />
-          </Suspense>
-        </main>
-      </div>
-
       <AnimatePresence>
         {forcePasswordModal && (
           <Suspense fallback={<div className="text-center mt-16 p-4"><AuthSpinner />تحميل نافذة تغيير كلمة المرور...</div>}>
             <ForcePasswordChangeModal onClose={() => setForcePasswordModal(false)} />
           </Suspense>
-       )}
+        )}
       </AnimatePresence>
-    </ResponsiveLayout>
+    </AppLayout>
   );
 };
 
 const AuthWrapper = () => (
   <MobileThemeProvider>
-    <AppWithQuery>
-      <NotificationProvider>
-        <DashboardContent />
-      </NotificationProvider>
-    </AppWithQuery>
+    <LanguageProvider>
+      <AppWithQuery>
+        <NotificationProvider>
+          <DashboardContent />
+        </NotificationProvider>
+      </AppWithQuery>
+    </LanguageProvider>
   </MobileThemeProvider>
 );
 


### PR DESCRIPTION
## Summary
- add LanguageContext for translation and direction switching
- create AppLayout and AppSidebar components with responsive behavior
- update header and dashboard page to use new layout and language toggle

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a928c5210c832896a37f341734678b