### PR TITLE
feat: centralize color palette with CSS variables

### DIFF
--- a/frontend/src/components/common/ModalComponent.jsx
+++ b/frontend/src/components/common/ModalComponent.jsx
@@ -5,13 +5,13 @@ const ModalComponent = ({ titleModal, onClose, ContentModal, isOpen }) => {
   if (!isOpen) return null;
 
   return (
-    <div className='fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 overflow-y-auto'>
-      <div className='w-full max-w-lg p-6 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded-lg shadow-lg m-4'>
+    <div className='fixed inset-0 flex items-center justify-center bg-black/50 z-50 overflow-y-auto'>
+      <div className='w-full max-w-lg p-6 bg-card text-card-foreground rounded-lg shadow-lg m-4'>
         <button onClick={onClose} className='text-xl focus:outline-none'>
           <FileClock />
         </button>
-        <div className='border-b pb-2 mb-4 text-center p-2 bg-violet-500'>
-          <h2 className='text-lg font-bold text-white dark:text-logic-violet'>
+        <div className='border-b pb-2 mb-4 text-center p-2 bg-primary'>
+          <h2 className='text-lg font-bold text-primary-foreground'>
             {titleModal}
           </h2>
         </div>

--- a/frontend/src/components/common/Tooltip.jsx
+++ b/frontend/src/components/common/Tooltip.jsx
@@ -33,11 +33,11 @@ function Tooltip({ children, className, bg, size, position }) {
   const colorClasses = (bg) => {
     switch (bg) {
       case 'light':
-        return 'bg-white text-gray-600 border-gray-200';
+        return 'bg-card text-muted-foreground border-border';
       case 'dark':
-        return 'bg-gray-800 text-gray-100 border-gray-700/60';
+        return 'bg-popover text-popover-foreground border-border';
       default:
-        return 'text-gray-600 bg-white dark:bg-gray-800 dark:text-gray-100 border-gray-200 dark:border-gray-700/60';
+        return 'bg-card text-muted-foreground border-border';
     }
   };
 
@@ -69,7 +69,7 @@ function Tooltip({ children, className, bg, size, position }) {
         onClick={(e) => e.preventDefault()}
       >
         <svg
-          className="fill-current text-gray-400 dark:text-gray-500"
+          className="fill-current text-muted-foreground"
           width="16"
           height="16"
           viewBox="0 0 16 16"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,6 +25,30 @@
     
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
+
+    /* Legacy palette mapped to CSS variables */
+    --greenic: 174 62% 40%;
+    --greenic-light: 174 62% 55%;
+    --greenic-dark: 174 62% 30%;
+    --greenic-darker: 174 62% 25%;
+
+    --royal: 220 65% 50%;
+    --royal-light: 220 65% 65%;
+    --royal-dark: 220 65% 35%;
+    --royal-darker: 220 65% 25%;
+    --royal-ultraDark: 220 65% 20%;
+    --royal-electric: 220 80% 60%;
+
+    --gold: 45 90% 55%;
+    --gold-light: 45 90% 65%;
+    --gold-dark: 45 90% 45%;
+
+    --navy: 210 60% 20%;
+    --navy-light: 210 60% 40%;
+    --navy-dark: 210 60% 15%;
+    --navy-darker: 210 60% 10%;
+
+    --reded: 0 80% 45%;
     
     /* Surface Colors */
     --background: 0 0% 100%;
@@ -81,6 +105,29 @@
   .dark {
     --background: 218 100% 6%;
     --foreground: 0 0% 98%;
+
+    --greenic: 174 62% 45%;
+    --greenic-light: 174 62% 65%;
+    --greenic-dark: 174 62% 35%;
+    --greenic-darker: 174 62% 25%;
+
+    --royal: 220 65% 45%;
+    --royal-light: 220 65% 60%;
+    --royal-dark: 220 65% 30%;
+    --royal-darker: 220 65% 25%;
+    --royal-ultraDark: 220 65% 20%;
+    --royal-electric: 220 80% 55%;
+
+    --gold: 45 90% 60%;
+    --gold-light: 45 90% 70%;
+    --gold-dark: 45 90% 50%;
+
+    --navy: 210 60% 12%;
+    --navy-light: 210 60% 25%;
+    --navy-dark: 210 60% 8%;
+    --navy-darker: 210 60% 6%;
+
+    --reded: 0 80% 55%;
     
     --card: 218 50% 8%;
     --card-foreground: 0 0% 98%;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -62,6 +62,36 @@ export default {
         'sidebar-accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
         'sidebar-border': 'hsl(var(--sidebar-border))',
         'sidebar-ring': 'hsl(var(--sidebar-ring))',
+
+        // Legacy palette
+        greenic: {
+          DEFAULT: 'hsl(var(--greenic))',
+          light: 'hsl(var(--greenic-light))',
+          dark: 'hsl(var(--greenic-dark))',
+          darker: 'hsl(var(--greenic-darker))',
+        },
+        royal: {
+          DEFAULT: 'hsl(var(--royal))',
+          light: 'hsl(var(--royal-light))',
+          dark: 'hsl(var(--royal-dark))',
+          darker: 'hsl(var(--royal-darker))',
+          ultraDark: 'hsl(var(--royal-ultraDark))',
+          electric: 'hsl(var(--royal-electric))',
+        },
+        gold: {
+          DEFAULT: 'hsl(var(--gold))',
+          light: 'hsl(var(--gold-light))',
+          dark: 'hsl(var(--gold-dark))',
+        },
+        navy: {
+          DEFAULT: 'hsl(var(--navy))',
+          light: 'hsl(var(--navy-light))',
+          dark: 'hsl(var(--navy-dark))',
+          darker: 'hsl(var(--navy-darker))',
+        },
+        reded: {
+          DEFAULT: 'hsl(var(--reded))',
+        },
       },
       borderRadius: {
         xl: '0.9rem',


### PR DESCRIPTION
## Summary
- introduce CSS variable palette for legacy colors like greenic, royal, gold and navy
- expose palette through Tailwind theme and map modal and tooltip components to new tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a93f3f4f18832897d3152da80e7183