### PR TITLE
Improve sidebar behavior and theming

### DIFF
--- a/frontend/src/components/dashboard/Header.jsx
+++ b/frontend/src/components/dashboard/Header.jsx
@@ -15,19 +15,25 @@ export default function Header({ isOpen, user, onToggleSidebar }) {
       className={`
         fixed top-0 left-0 right-0
         transition-all duration-300
-        ${isOpen ? 'sm:mr-64' : 'sm:mr-16'}
+        ${isOpen
+          ? dir === 'rtl'
+            ? 'sm:mr-64'
+            : 'sm:ml-64'
+          : dir === 'rtl'
+          ? 'sm:mr-16'
+          : 'sm:ml-16'}
         py-3 px-6 flex justify-between items-center
-        bg-navy-light dark:bg-black
+        bg-gold-light dark:bg-navy-darker
         bg-gradient-to-l from-gold via-greenic/80 to-royal/80
-        dark:bg-gradient-to-l dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
-        text-gray-900 dark:text-white
+        dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
+        text-gray-900 dark:text-gold-light
         border-b border-gray-200 dark:border-navy-dark
         shadow-md dark:shadow-[0_01px_#16b8f640]
         z-20
       `}
     >
       <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
-        <Menu className="text-white dark:text-greenic h-5 w-5 hover:text-greenic-light" />
+        <Menu className="text-greenic-dark dark:text-gold-light h-5 w-5 hover:text-greenic-light" />
       </Button>
 
       <div className="flex items-center gap-3">

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -16,9 +16,15 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
   const { t, dir } = useLanguage();
   const [activeSection, setActiveSection] = useState(null);
   const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth >= 1024);
+  const [isTablet, setIsTablet] = useState(
+    window.innerWidth >= 768 && window.innerWidth < 1024
+  );
 
   useEffect(() => {
-    const handleResize = () => setIsLargeScreen(window.innerWidth >= 1024);
+    const handleResize = () => {
+      setIsLargeScreen(window.innerWidth >= 1024);
+      setIsTablet(window.innerWidth >= 768 && window.innerWidth < 1024);
+    };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
@@ -69,8 +75,19 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
       className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0'} top-0 z-20 h-full bg-gold dark:bg-navy-darker
         bg-gradient-to-b from-gold via-greenic-dark/50 to-royal/80
         dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/40
+        text-greenic-dark dark:text-gold-light
         transition-all duration-300
-        ${isLargeScreen ? (isOpen ? 'w-64' : 'w-16') : (isOpen ? 'w-full mt-12' : `${dir === 'rtl' ? 'translate-x-full' : '-translate-x-full'}`)}
+        ${isLargeScreen
+          ? isOpen
+            ? 'w-64'
+            : 'w-16'
+          : isTablet
+          ? isOpen
+            ? 'w-full'
+            : 'w-16'
+          : isOpen
+          ? 'w-full mt-12'
+          : `${dir === 'rtl' ? 'translate-x-full' : '-translate-x-full'}`}
       `}
     >
       <div className="flex items-center justify-center p-0 mt-6">


### PR DESCRIPTION
## Summary
- handle RTL/LTR margins for header and content
- refine sidebar for tablet screens and auto-close links
- update header and sidebar styles for dark/light themes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9470ad55483288ed81dad992b0613