### PR TITLE
feat: extend PDF viewer to support spreadsheets

### DIFF
--- a/frontend/src/components/PDFViewer.jsx
+++ b/frontend/src/components/PDFViewer.jsx
@@ -1,49 +1,90 @@
 // src/components/PDFViewer.jsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
+import XLSX from 'xlsx-js-style';
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
 import {
-  ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCw, Download
+  ChevronLeft,
+  ChevronRight,
+  ZoomIn,
+  ZoomOut,
+  RotateCw,
+  Download,
 } from 'lucide-react';
 
-pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 
 export default function PDFViewer({ fileUrl, isRtl = true }) {
   const [numPages, setNumPages] = useState(null);
   const [pageNumber, setPageNumber] = useState(1);
   const [scale, setScale] = useState(1.0);
   const [rotation, setRotation] = useState(0);
+  const [sheetHtml, setSheetHtml] = useState(null);
+
+  const isXlsx = fileUrl?.toLowerCase().endsWith('.xlsx');
+
+  useEffect(() => {
+    if (!isXlsx) return;
+    setSheetHtml(null);
+    fetch(fileUrl)
+      .then((res) => res.arrayBuffer())
+      .then((ab) => {
+        const wb = XLSX.read(ab, { type: 'array' });
+        const sheet = wb.Sheets[wb.SheetNames[0]];
+        const html = XLSX.utils.sheet_to_html(sheet, { header: '', footer: '' });
+        setSheetHtml(html);
+      })
+      .catch((e) => console.error('XLSX load error:', e));
+  }, [fileUrl, isXlsx]);
 
   const onDocumentLoadSuccess = ({ numPages }) => {
     setNumPages(numPages);
     setPageNumber(1);
   };
 
-  const downloadPdf = () => {
+  const downloadFile = () => {
     const link = document.createElement('a');
     link.href = fileUrl;
-    link.download = 'document.pdf';
+    link.download = fileUrl.split('/').pop() || 'document';
     link.click();
   };
+
+  if (isXlsx) {
+    return (
+      <div dir={isRtl ? 'rtl' : 'ltr'} className="space-y-4">
+        <div className="flex justify-end bg-white p-2 rounded shadow">
+          <button onClick={downloadFile} className="text-gray-700 hover:text-blue-600">
+            <Download />
+          </button>
+        </div>
+        <div
+          className="bg-white p-4 border rounded shadow-md overflow-auto"
+          dangerouslySetInnerHTML={{ __html: sheetHtml || '' }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div dir={isRtl ? 'rtl' : 'ltr'} className="space-y-4">
       {/* Controls */}
       <div className="flex flex-wrap gap-2 justify-between items-center bg-white p-2 rounded shadow">
         <div className="flex gap-2">
-          <button 
-            onClick={() => setPageNumber(p => Math.max(p - 1, 1))} 
+          <button
+            onClick={() => setPageNumber((p) => Math.max(p - 1, 1))}
             disabled={pageNumber <= 1}
             className="text-gray-700 hover:text-blue-600"
           >
             <ChevronLeft />
           </button>
           <span className="text-sm px-2">
-            {isRtl ? `الصفحة ${pageNumber} من ${numPages}` : `Page ${pageNumber} of ${numPages}`}
+            {isRtl
+              ? `الصفحة ${pageNumber} من ${numPages}`
+              : `Page ${pageNumber} of ${numPages}`}
           </span>
-          <button 
-            onClick={() => setPageNumber(p => Math.min(p + 1, numPages))} 
+          <button
+            onClick={() => setPageNumber((p) => Math.min(p + 1, numPages))}
             disabled={pageNumber >= numPages}
             className="text-gray-700 hover:text-blue-600"
           >
@@ -52,16 +93,28 @@ export default function PDFViewer({ fileUrl, isRtl = true }) {
         </div>
 
         <div className="flex gap-2">
-          <button onClick={() => setScale(s => Math.min(s + 0.25, 3))} className="text-gray-700 hover:text-green-600">
+          <button
+            onClick={() => setScale((s) => Math.min(s + 0.25, 3))}
+            className="text-gray-700 hover:text-green-600"
+          >
             <ZoomIn />
           </button>
-          <button onClick={() => setScale(s => Math.max(s - 0.25, 0.5))} className="text-gray-700 hover:text-red-600">
+          <button
+            onClick={() => setScale((s) => Math.max(s - 0.25, 0.5))}
+            className="text-gray-700 hover:text-red-600"
+          >
             <ZoomOut />
           </button>
-          <button onClick={() => setRotation(r => (r + 90) % 360)} className="text-gray-700 hover:text-purple-600">
+          <button
+            onClick={() => setRotation((r) => (r + 90) % 360)}
+            className="text-gray-700 hover:text-purple-600"
+          >
             <RotateCw />
           </button>
-          <button onClick={downloadPdf} className="text-gray-700 hover:text-blue-600">
+          <button
+            onClick={downloadFile}
+            className="text-gray-700 hover:text-blue-600"
+          >
             <Download />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- support viewing `.xlsx` files by parsing them with `xlsx-js-style`
- render either PDF or spreadsheet based on file extension
- use `pdfjs` version for worker to keep viewer in sync

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9682eb68483289850456b17f56b08