### PR TITLE
refactor: migrate UI theme to unified design tokens

### DIFF
--- a/frontend/README-THEME.md
+++ b/frontend/README-THEME.md
@@ -1,0 +1,35 @@
+# Theme Tokens
+
+The application uses a unified set of CSS variables stored in `src/styles/tokens.css`. These variables define both light and dark themes and are consumed through Tailwind in `tailwind.config.js`.
+
+## Tokens
+- **background / foreground** – base surfaces and text.
+- **primary** – main actions.
+- **secondary** – secondary surfaces or actions.
+- **accent** – decorative highlights.
+- **muted** – subtle backgrounds and text.
+- **success / warning / destructive** – status feedback.
+- **card / popover** – generic surfaces.
+- **sidebar** – dedicated palette for the navigation sidebar.
+- **gradients** – `--gradient-primary`, `--gradient-secondary`, `--gradient-hero`, `--gradient-card`.
+- **shadows** – `--shadow-sm`, `--shadow-md`, `--shadow-lg`, `--shadow-xl`, `--shadow-glow`.
+- **fonts** – `--font-heading`, `--font-body`.
+
+## Adding a new theme
+Override the variables under a new class and apply it on the root element:
+
+```css
+.theme-ocean {
+  --primary: 200 80% 45%;
+  --primary-foreground: 0 0% 100%;
+  /* other overrides */
+}
+```
+
+## Choosing tokens by role
+- **Primary** for prominent call‑to‑action buttons.
+- **Secondary** for muted buttons and panels.
+- **Accent** for attention or decorative elements.
+- **Muted** for borders or background fillers.
+- **Status** colors for success, warning or destructive messages.
+- Always pair background tokens with their `*-foreground` text token for contrast.

--- a/frontend/src/components/dashboard/Header.jsx
+++ b/frontend/src/components/dashboard/Header.jsx
@@ -23,17 +23,13 @@ export default function Header({ isOpen, user, onToggleSidebar }) {
           ? 'sm:mr-16'
           : 'sm:ml-16'}
         py-3 px-6 flex justify-between items-center
-        bg-gold-light dark:bg-navy-darker
-        bg-gradient-to-l from-gold via-greenic/80 to-royal/80
-        dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
-        text-gray-900 dark:text-gold-light
-        border-b border-gray-200 dark:border-navy-dark
-        shadow-md dark:shadow-[0_01px_#16b8f640]
+        bg-card text-foreground
+        border-b border-border shadow-md
         z-20
       `}
     >
       <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
-        <Menu className="text-greenic-dark dark:text-gold-light h-5 w-5 hover:text-greenic-light" />
+        <Menu className="h-5 w-5 text-foreground hover:text-primary" />
       </Button>
 
       <div className="flex items-center gap-3">

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -56,7 +56,7 @@ export default function AppLayout({ children, user }) {
         />
         {(isMobile || isTablet) && sidebarOpen && (
           <div
-            className="fixed inset-0 bg-black/50 z-10"
+            className="fixed inset-0 bg-foreground/50 z-10"
             onClick={() => setSidebarOpen(false)}
           />
         )}
@@ -68,7 +68,7 @@ export default function AppLayout({ children, user }) {
         <main
           className={`
             flex-1 px-4 sm:px-6 lg:px-8
-            bg-greenic-light/10 dark:bg-greenic-darker/20
+            bg-background
             transition-all duration-500
             ${isMobile ? 'mobile-main' : 'desktop-main'}
             ${isStandalone ? 'standalone-main' : ''}

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -72,12 +72,8 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
   return (
     <aside
       dir={dir}
-      className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0'} top-0 z-20 h-full bg-gold dark:bg-navy-darker
-        bg-gradient-to-b from-gold via-greenic-dark/50 to-royal/80
-        dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/40
-        text-greenic-dark dark:text-gold-light
-        transition-all duration-300
-        ${isLargeScreen
+      className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0'} top-0 z-20 h-full bg-sidebar text-sidebar-foreground border-r border-sidebar-border transition-all duration-300 ${
+        isLargeScreen
           ? isOpen
             ? 'w-64'
             : 'w-16'
@@ -87,8 +83,8 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
             : 'w-16'
           : isOpen
           ? 'w-full mt-12'
-          : `${dir === 'rtl' ? 'translate-x-full' : '-translate-x-full'}`}
-      `}
+          : `${dir === 'rtl' ? 'translate-x-full' : '-translate-x-full'}`
+      }`}
     >
       <div className="flex items-center justify-center p-0 mt-6">
         <img src={logoSrc} alt="Logo" className={`transition-all duration-300 ${isOpen ? 'w-36' : 'w-10'}`} />
@@ -103,19 +99,21 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
                 to={item.to}
                 onClick={onLinkClick}
                 className={({ isActive }) =>
-                  `group flex items-center gap-3 p-2 rounded-md text-sm font-semibold tracking-tight transition-all duration-300
-                   ${isActive
-                     ? 'bg-greenic-dark text-gold-light dark:bg-greenic-light/80 dark:text-royal-dark'
-                     : 'text-white dark:text-greenic-light hover:bg-gold-light hover:text-greenic-dark dark:hover:bg-greenic-light/50 dark:hover:text-white'}`
+                  `group flex items-center gap-3 p-2 rounded-md text-sm font-semibold tracking-tight transition-all duration-300 ${
+                    isActive
+                      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                      : 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'
+                  }`
                 }
               >
                 {({ isActive }) => (
                   <>
                     {React.cloneElement(item.icon, {
-                      className: `transition-colors duration-200
-                        ${isActive
-                          ? 'text-gold-light dark:text-royal-darker'
-                          : 'text-white group-hover:text-greenic-dark dark:group-hover:text-white'}`
+                      className: `transition-colors duration-200 ${
+                        isActive
+                          ? 'text-sidebar-accent-foreground'
+                          : 'text-sidebar-foreground group-hover:text-sidebar-accent-foreground'
+                      }`
                     })}
                     <span className="flex-1 text-right">{item.label}</span>
                   </>
@@ -124,48 +122,53 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
             ) : (
               <button
                 onClick={() => handleSectionClick(item.id, !!item.children)}
-                className={`flex items-center gap-3 p-2 w-full rounded-md text-sm font-semibold tracking-tight transition-colors duration-200
-                  ${activeSection === item.id
-                    ? 'bg-gold-light text-greenic dark:bg-greenic-light/40 dark:text-gold'
-                    : 'text-white dark:text-greenic-light hover:bg-gold-light hover:text-greenic-dark dark:hover:bg-greenic-light/30 dark:hover:text-white'}`}
+                className={`flex items-center gap-3 p-2 w-full rounded-md text-sm font-semibold tracking-tight transition-colors duration-200 ${
+                  activeSection === item.id
+                    ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                    : 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'
+                }`}
               >
                 {React.cloneElement(item.icon, {
-                  className: `transition-colors duration-200
-                    ${activeSection === item.id
-                      ? 'text-gold-light dark:text-gold'
-                      : 'text-white group-hover:text-greenic-dark dark:group-hover:text-gold'}`
+                  className: `transition-colors duration-200 ${
+                    activeSection === item.id
+                      ? 'text-sidebar-accent-foreground'
+                      : 'text-sidebar-foreground group-hover:text-sidebar-accent-foreground'
+                  }`
                 })}
                 <span className="flex-1 text-right">{item.label}</span>
                 {item.children && (
                   <ChevronRight
-                    className={`w-4 h-4 transform transition-transform duration-200
-                      ${activeSection === item.id ? (dir === 'rtl' ? 'rotate-90' : '-rotate-90') : ''}`}
+                    className={`w-4 h-4 transform transition-transform duration-200 ${
+                      activeSection === item.id ? (dir === 'rtl' ? 'rotate-90' : '-rotate-90') : ''
+                    }`}
                   />
                 )}
               </button>
             )}
 
             {item.children && activeSection === item.id && isOpen && (
-              <div className="mr-4 pl-4 border-r border-gray-600 space-y-1">
+              <div className="mr-4 pl-4 border-r border-sidebar-border space-y-1">
                 {item.children.map(ch => (
                   <NavLink
                     key={ch.id}
                     to={ch.to}
                     onClick={onLinkClick}
                     className={({ isActive }) =>
-                      `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-300
-                       ${isActive
-                         ? 'bg-gold-light/90 text-greenic-dark dark:bg-greenic-light/60 dark:text-white'
-                         : 'text-white dark:text-greenic-light hover:bg-gold-light hover:text-greenic-dark dark:hover:bg-greenic-light/50 dark:hover:text-gold'}`
+                      `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-300 ${
+                        isActive
+                          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                          : 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'
+                      }`
                     }
                   >
                     {({ isActive }) => (
                       <>
                         {React.cloneElement(ch.icon, {
-                          className: `transition duration-200
-                            ${isActive
-                              ? 'text-greenic-dark dark:text-white'
-                              : 'group-hover:text-greenic-dark dark:group-hover:text-white'}`
+                          className: `transition duration-200 ${
+                            isActive
+                              ? 'text-sidebar-accent-foreground'
+                              : 'text-sidebar-foreground group-hover:text-sidebar-accent-foreground'
+                          }`
                         })}
                         <span>{ch.label}</span>
                       </>
@@ -187,18 +190,20 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
                 onClick={onLinkClick}
                 title={it.label}
                 className={({ isActive }) =>
-                  `px-4 py-2 rounded-md transition-all duration-200 font-semibold tracking-tight flex items-center gap-2 group
-                   ${isActive
-                     ? 'bg-greenic-dark text-gold-light shadow-md dark:bg-greenic-light/60 dark:text-gold-light'
-                     : 'text-white hover:bg-gold-light/70 hover:text-greenic dark:hover:bg-greenic/50 dark:text-gold-light'}`
+                  `px-4 py-2 rounded-md transition-all duration-200 font-semibold tracking-tight flex items-center gap-2 group ${
+                    isActive
+                      ? 'bg-sidebar-accent text-sidebar-accent-foreground shadow-md'
+                      : 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'
+                  }`
                 }
               >
                 {({ isActive }) =>
                   React.cloneElement(it.icon, {
-                    className: `transition duration-200
-                      ${isActive
-                        ? 'text-gold-light dark:text-gold-light'
-                        : 'dark:text-gold-light group-hover:text-greenic-dark dark:group-hover:text-white'}`
+                    className: `transition duration-200 ${
+                      isActive
+                        ? 'text-sidebar-accent-foreground'
+                        : 'text-sidebar-foreground group-hover:text-sidebar-accent-foreground'
+                    }`
                   })
                 }
               </NavLink>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -3,24 +3,18 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
-// ✅ زر Tailwind مع دعم ألوان custom و theme متقدم
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors ring-offset-background focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
   {
     variants: {
       variant: {
-        default:
-          "bg-greenic text-white hover:bg-greenic-dark dark:bg-greenic-dark dark:hover:bg-greenic text-white",
-        royal:
-          "bg-royal hover:bg-royal-dark text-white dark:bg-royal-dark dark:hover:bg-royal-ultraDark",
-        gold:
-          "bg-gold text-white hover:bg-gold-dark dark:bg-gold-dark dark:hover:bg-gold-light",
-        outline:
-          "border border-border bg-white text-gray-800 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700",
-        ghost:
-          "bg-transparent text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700",
-        link:
-          "bg-transparent text-royal underline hover:text-royal-dark dark:text-royal-electric dark:hover:text-royal-ultraDark",
+        default: "bg-primary text-primary-foreground hover:bg-primary-hover",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary-hover",
+        accent: "bg-accent text-accent-foreground hover:bg-accent-hover",
+        destructive: "bg-destructive text-destructive-foreground hover:opacity-90",
+        outline: "border border-border bg-background text-foreground hover:bg-muted",
+        ghost: "bg-transparent text-foreground hover:bg-muted",
+        link: "bg-transparent text-primary underline-offset-4 hover:text-primary-hover",
       },
       size: {
         default: "h-10 px-4 py-2",
@@ -56,13 +50,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-// ✅ مثال تطبيقي للاستخدام
 const ButtonCollection = () => {
   return (
     <div className="flex flex-wrap gap-4 p-4 bg-background text-foreground rounded-lg shadow-md">
-      <Button variant="default">الافتراضي</Button>
-      <Button variant="royal">ملكي</Button>
-      <Button variant="gold">ذهبي</Button>
+      <Button variant="default">أساسي</Button>
+      <Button variant="secondary">ثانوي</Button>
+      <Button variant="accent">مميز</Button>
+      <Button variant="destructive">خطر</Button>
       <Button variant="outline">حدود</Button>
       <Button variant="ghost">شفاف</Button>
       <Button variant="link">رابط</Button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,150 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+@import './styles/tokens.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Madar Design System - Arabic RTL Legal Management App */
-
-@layer base {
-  :root {
-    /* Madar Brand Colors */
-    --primary: 222 64% 22%;
-    --primary-foreground: 0 0% 98%;
-    --primary-muted: 222 44% 16%;
-
-    --accent: 188 68% 42%;
-    --accent-foreground: 222 64% 10%;
-    --accent-light: 188 55% 84%;
-
-    --success: 142 45% 36%;
-    --success-foreground: 0 0% 98%;
-
-    --warning: 38 92% 52%;
-    --warning-foreground: 230 20% 12%;
-
-    --destructive: 0 72% 48%;
-    --destructive-foreground: 0 0% 98%;
-
-    /* Legacy palette mapped to CSS variables */
-    --greenic: 174 62% 40%;
-    --greenic-light: 174 62% 55%;
-    --greenic-dark: 174 62% 30%;
-    --greenic-darker: 174 62% 24%;
-
-    --royal: 228 70% 54%;
-    --royal-light: 228 70% 66%;
-    --royal-dark: 228 70% 38%;
-    --royal-darker: 228 70% 28%;
-    --royal-ultraDark: 228 70% 22%;
-    --royal-electric: 228 82% 60%;
-
-    --gold: 45 92% 56%;
-    --gold-light: 45 92% 66%;
-    --gold-dark: 45 92% 46%;
-
-    --navy: 220 50% 20%;
-    --navy-light: 220 50% 38%;
-    --navy-dark: 220 50% 14%;
-    --navy-darker: 220 50% 10%;
-
-    --reded: 0 72% 48%;
-    
-    /* Surface Colors */
-    --background: 0 0% 100%;
-    --foreground: 222 22% 12%;
-    
-    --card: 0 0% 100%;
-    --card-foreground: 222 22% 12%;
-    --card-hover: 0 0% 97%;
-
-    --muted: 215 20% 96%;
-    --muted-foreground: 215 16% 45%;
-
-    --secondary: 188 45% 96%;
-    --secondary-foreground: 222 22% 12%;
-
-    /* Interactive Elements */
-    --border: 215 22% 88%;
-    --input: 215 22% 88%;
-    --ring: 188 68% 44%;
-
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 22% 12%;
-
-    /* Sidebar */
-    --sidebar-background: 222 40% 10%;
-    --sidebar-foreground: 0 0% 98%;
-    --sidebar-primary: 188 68% 46%;
-    --sidebar-primary-foreground: 222 22% 12%;
-    --sidebar-accent: 222 28% 16%;
-    --sidebar-accent-foreground: 0 0% 98%;
-    --sidebar-border: 222 28% 18%;
-    --sidebar-ring: 188 68% 44%;
-    
-    /* Design tokens */
-    --radius: 12px;
-    --shadow-elegant: 0 10px 30px -10px hsl(var(--primary) / 0.10);
-    --shadow-card: 0 4px 12px -2px hsl(var(--primary) / 0.08);
-    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-muted)));
-    --gradient-accent: linear-gradient(135deg, hsl(var(--accent)), hsl(var(--accent-light)));
-    --gradient-hero: radial-gradient(circle at 60% 40%, hsl(var(--accent) / 0.35), transparent 65%);
-    --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    
-    /* Typography */
-    --font-size-xs: 0.75rem;
-    --font-size-sm: 0.875rem;
-    --font-size-base: 1rem;
-    --font-size-lg: 1.125rem;
-    --font-size-xl: 1.25rem;
-    --font-size-2xl: 1.5rem;
-    --font-size-3xl: 1.875rem;
-    --font-size-4xl: 2.25rem;
-  }
-
-  .dark {
-    --background: 222 33% 7%;
-    --foreground: 0 0% 98%;
-
-    --primary: 222 65% 46%;
-    --primary-foreground: 0 0% 98%;
-    --primary-muted: 222 50% 36%;
-
-    --accent: 188 68% 48%;
-    --accent-foreground: 222 64% 10%;
-
-    --success: 142 48% 40%;
-    --success-foreground: 0 0% 98%;
-    --warning: 38 95% 56%;
-    --warning-foreground: 230 20% 12%;
-    --destructive: 0 74% 54%;
-    --destructive-foreground: 0 0% 98%;
-
-    --card: 222 28% 10%;
-    --card-foreground: 0 0% 98%;
-
-    --muted: 222 20% 14%;
-    --muted-foreground: 215 18% 70%;
-
-    --secondary: 222 24% 12%;
-    --secondary-foreground: 0 0% 98%;
-
-    --border: 222 18% 18%;
-    --input: 222 18% 18%;
-
-    --popover: 222 28% 10%;
-    --popover-foreground: 0 0% 98%;
-
-    --sidebar-background: 222 33% 5%;
-    --sidebar-foreground: 0 0% 98%;
-    --sidebar-primary: 188 68% 50%;
-    --sidebar-primary-foreground: 222 22% 12%;
-    --sidebar-accent: 222 26% 12%;
-    --sidebar-accent-foreground: 0 0% 98%;
-    --sidebar-border: 222 24% 14%;
-    --sidebar-ring: 188 68% 50%;
-  }
-}
 
 @layer base {
   * {
@@ -152,7 +12,7 @@
   }
 
   html {
-    font-family: 'Cairo', system-ui, sans-serif;
+    font-family: var(--font-body);
     direction: rtl;
     lang: ar;
   }
@@ -162,7 +22,6 @@
     font-feature-settings: 'rlig' 1, 'calt' 1;
   }
 
-  /* RTL-specific adjustments */
   [dir="rtl"] {
     text-align: right;
   }
@@ -174,7 +33,6 @@
 }
 
 @layer components {
-  /* Custom scrollbar */
   .scrollbar-thin::-webkit-scrollbar {
     width: 6px;
     height: 6px;
@@ -192,7 +50,6 @@
     @apply bg-muted-foreground;
   }
 
-  /* Animations */
   .animate-fade-in {
     animation: fadeIn 0.3s ease-in-out;
   }
@@ -249,15 +106,5 @@
   to {
     opacity: 1;
     transform: scale(1);
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-
-  body {
-    @apply bg-background text-foreground;
   }
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,126 @@
+:root {
+  --font-heading: 'Inter', sans-serif;
+  --font-body: 'Cairo', sans-serif;
+
+  --background: 0 0% 100%;
+  --foreground: 222 22% 12%;
+
+  --primary: 222 64% 22%;
+  --primary-foreground: 0 0% 98%;
+  --primary-hover: 222 64% 26%;
+  --primary-light: 222 64% 40%;
+
+  --secondary: 188 45% 96%;
+  --secondary-foreground: 222 22% 12%;
+  --secondary-hover: 188 45% 90%;
+
+  --accent: 188 68% 42%;
+  --accent-foreground: 222 64% 10%;
+  --accent-hover: 188 68% 46%;
+
+  --muted: 215 20% 96%;
+  --muted-foreground: 215 16% 45%;
+
+  --success: 142 45% 36%;
+  --success-foreground: 0 0% 98%;
+
+  --warning: 38 92% 52%;
+  --warning-foreground: 230 20% 12%;
+
+  --destructive: 0 72% 48%;
+  --destructive-foreground: 0 0% 98%;
+
+  --border: 215 22% 88%;
+  --input: 215 22% 88%;
+  --ring: 188 68% 44%;
+
+  --card: 0 0% 100%;
+  --card-foreground: 222 22% 12%;
+  --card-hover: 0 0% 97%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 222 22% 12%;
+
+  --sidebar: 222 40% 10%;
+  --sidebar-foreground: 0 0% 98%;
+  --sidebar-primary: 188 68% 46%;
+  --sidebar-primary-foreground: 222 22% 12%;
+  --sidebar-accent: 222 28% 16%;
+  --sidebar-accent-foreground: 0 0% 98%;
+  --sidebar-border: 222 28% 18%;
+  --sidebar-ring: 188 68% 44%;
+
+  --radius: 12px;
+
+  --shadow-sm: 0 1px 2px hsl(var(--foreground) / 0.05);
+  --shadow-md: 0 4px 6px -1px hsl(var(--foreground) / 0.1), 0 2px 4px -2px hsl(var(--foreground) / 0.1);
+  --shadow-lg: 0 10px 15px -3px hsl(var(--foreground) / 0.1), 0 4px 6px -4px hsl(var(--foreground) / 0.1);
+  --shadow-xl: 0 20px 25px -5px hsl(var(--foreground) / 0.1), 0 8px 10px -6px hsl(var(--foreground) / 0.1);
+  --shadow-glow: 0 0 8px 2px hsl(var(--accent) / 0.5);
+
+  --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-light)));
+  --gradient-secondary: linear-gradient(135deg, hsl(var(--secondary)), hsl(var(--accent)));
+  --gradient-hero: radial-gradient(circle at 60% 40%, hsl(var(--accent) / 0.35), transparent 65%);
+  --gradient-card: linear-gradient(135deg, hsl(var(--card)), hsl(var(--card-hover)));
+}
+
+.dark {
+  --background: 222 33% 7%;
+  --foreground: 0 0% 98%;
+
+  --primary: 222 65% 46%;
+  --primary-foreground: 0 0% 98%;
+  --primary-hover: 222 65% 52%;
+  --primary-light: 222 65% 60%;
+
+  --secondary: 222 28% 10%;
+  --secondary-foreground: 0 0% 98%;
+  --secondary-hover: 222 28% 14%;
+
+  --accent: 188 68% 48%;
+  --accent-foreground: 222 64% 10%;
+  --accent-hover: 188 68% 54%;
+
+  --muted: 222 28% 18%;
+  --muted-foreground: 215 16% 65%;
+
+  --success: 142 48% 40%;
+  --success-foreground: 0 0% 98%;
+
+  --warning: 38 95% 56%;
+  --warning-foreground: 230 20% 12%;
+
+  --destructive: 0 74% 54%;
+  --destructive-foreground: 0 0% 98%;
+
+  --border: 222 24% 14%;
+  --input: 222 24% 14%;
+  --ring: 188 68% 50%;
+
+  --card: 222 28% 10%;
+  --card-foreground: 0 0% 98%;
+  --card-hover: 222 28% 14%;
+
+  --popover: 222 28% 10%;
+  --popover-foreground: 0 0% 98%;
+
+  --sidebar: 222 33% 7%;
+  --sidebar-foreground: 0 0% 98%;
+  --sidebar-primary: 188 68% 50%;
+  --sidebar-primary-foreground: 222 22% 12%;
+  --sidebar-accent: 222 26% 12%;
+  --sidebar-accent-foreground: 0 0% 98%;
+  --sidebar-border: 222 24% 14%;
+  --sidebar-ring: 188 68% 50%;
+
+  --shadow-sm: 0 1px 2px hsl(var(--foreground) / 0.3);
+  --shadow-md: 0 4px 6px -1px hsl(var(--foreground) / 0.3), 0 2px 4px -2px hsl(var(--foreground) / 0.3);
+  --shadow-lg: 0 10px 15px -3px hsl(var(--foreground) / 0.35), 0 4px 6px -4px hsl(var(--foreground) / 0.35);
+  --shadow-xl: 0 20px 25px -5px hsl(var(--foreground) / 0.4), 0 8px 10px -6px hsl(var(--foreground) / 0.4);
+  --shadow-glow: 0 0 8px 2px hsl(var(--accent) / 0.6);
+
+  --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-hover)));
+  --gradient-secondary: linear-gradient(135deg, hsl(var(--secondary)), hsl(var(--accent)));
+  --gradient-hero: radial-gradient(circle at 60% 40%, hsl(var(--accent) / 0.25), transparent 65%);
+  --gradient-card: linear-gradient(135deg, hsl(var(--card)), hsl(var(--card-hover)));
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,11 +2,8 @@ import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
 
 export default {
-  darkMode: ['class', '[data-theme="dark"]'],
-  content: [
-    './index.html',
-    './src/**/*.{js,jsx,ts,tsx}',
-  ],
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     container: {
       center: true,
@@ -15,103 +12,83 @@ export default {
     },
     extend: {
       colors: {
-        // الأساسيات المطابقة لـ index.css
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
-
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
-
-        card: 'hsl(var(--card))',
-        'card-foreground': 'hsl(var(--card-foreground))',
-        'card-hover': 'hsl(var(--card-hover))',
-
-        muted: 'hsl(var(--muted))',
-        'muted-foreground': 'hsl(var(--muted-foreground))',
-
-        secondary: 'hsl(var(--secondary))',
-        'secondary-foreground': 'hsl(var(--secondary-foreground))',
-
-        primary: 'hsl(var(--primary))',
-        'primary-foreground': 'hsl(var(--primary-foreground))',
-        'primary-muted': 'hsl(var(--primary-muted))',
-
-        accent: 'hsl(var(--accent))',
-        'accent-foreground': 'hsl(var(--accent-foreground))',
-        'accent-light': 'hsl(var(--accent-light))',
-
-        success: 'hsl(var(--success))',
-        'success-foreground': 'hsl(var(--success-foreground))',
-
-        warning: 'hsl(var(--warning))',
-        'warning-foreground': 'hsl(var(--warning-foreground))',
-
-        destructive: 'hsl(var(--destructive))',
-        'destructive-foreground': 'hsl(var(--destructive-foreground))',
-
-        popover: 'hsl(var(--popover))',
-        'popover-foreground': 'hsl(var(--popover-foreground))',
-
-        // ألوان الـ Sidebar
-        'sidebar-background': 'hsl(var(--sidebar-background))',
-        'sidebar-foreground': 'hsl(var(--sidebar-foreground))',
-        'sidebar-primary': 'hsl(var(--sidebar-primary))',
-        'sidebar-primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-        'sidebar-accent': 'hsl(var(--sidebar-accent))',
-        'sidebar-accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-        'sidebar-border': 'hsl(var(--sidebar-border))',
-        'sidebar-ring': 'hsl(var(--sidebar-ring))',
-
-        // Legacy palette
-        greenic: {
-          DEFAULT: 'hsl(var(--greenic))',
-          light: 'hsl(var(--greenic-light))',
-          dark: 'hsl(var(--greenic-dark))',
-          darker: 'hsl(var(--greenic-darker))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+          hover: 'hsl(var(--primary-hover))',
+          light: 'hsl(var(--primary-light))',
         },
-        royal: {
-          DEFAULT: 'hsl(var(--royal))',
-          light: 'hsl(var(--royal-light))',
-          dark: 'hsl(var(--royal-dark))',
-          darker: 'hsl(var(--royal-darker))',
-          ultraDark: 'hsl(var(--royal-ultraDark))',
-          electric: 'hsl(var(--royal-electric))',
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+          hover: 'hsl(var(--secondary-hover))',
         },
-        gold: {
-          DEFAULT: 'hsl(var(--gold))',
-          light: 'hsl(var(--gold-light))',
-          dark: 'hsl(var(--gold-dark))',
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+          hover: 'hsl(var(--accent-hover))',
         },
-        navy: {
-          DEFAULT: 'hsl(var(--navy))',
-          light: 'hsl(var(--navy-light))',
-          dark: 'hsl(var(--navy-dark))',
-          darker: 'hsl(var(--navy-darker))',
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
         },
-        reded: {
-          DEFAULT: 'hsl(var(--reded))',
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+          hover: 'hsl(var(--card-hover))',
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
         },
       },
-      borderRadius: {
-        xl: '0.9rem',
-        '2xl': '1.25rem',
-        '2xl': '1.25rem',
+      backgroundImage: {
+        'gradient-primary': 'var(--gradient-primary)',
+        'gradient-secondary': 'var(--gradient-secondary)',
+        'gradient-hero': 'var(--gradient-hero)',
+        'gradient-card': 'var(--gradient-card)',
       },
       boxShadow: {
-        soft: '0 6px 24px rgba(0,0,0,0.06)',
-        focus: '0 0 0 4px rgba(56,189,248,0.25)',
-        card: '0 10px 40px rgba(0,0,0,0.08)',
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)',
+        xl: 'var(--shadow-xl)',
+        glow: 'var(--shadow-glow)',
       },
-   backgroundImage: {
-        'gradient-brand': 'linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--accent)) 100%)',
-        'gradient-hero': 'var(--gradient-hero)',
-        'gradient-primary': 'var(--gradient-primary)',
-        'gradient-accent': 'var(--gradient-accent)',
+      fontFamily: {
+        heading: ['var(--font-heading)'],
+        body: ['var(--font-body)'],
       },
-      transitionTimingFunction: {
-        'ease-soft': 'cubic-bezier(.2,.8,.2,1)',
-        'ease-smooth': 'var(--transition-smooth)',
+      borderRadius: {
+        xl: '0.75rem',
+        '2xl': '1rem',
       },
     },
   },


### PR DESCRIPTION
## Summary
- unify light/dark variables in new `tokens.css` and expose them in Tailwind config
- migrate sidebar, layout, header and button components to design tokens
- document token usage in README-THEME

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa10392d54832891885f6e8257dbef