### PR TITLE
feat: improve primary contrast in light theme

### DIFF
--- a/frontend/src/styles/Tokens.mdx
+++ b/frontend/src/styles/Tokens.mdx
@@ -2,7 +2,7 @@ import React from 'react';
 
 # CaribeKS Upgraded Tokens
 
-Light and dark mode tokens are defined as CSS variables and consumed via Tailwind classes.
+Light and dark mode tokens are defined as CSS variables and consumed via Tailwind classes. The light theme now uses a deeper olive primary to improve contrast for Arabic text.
 
 ```tsx
 <div className="p-4 bg-card text-card-foreground rounded-lg shadow">

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -17,9 +17,9 @@
   --ring: #2A8DD4;   /* Accent */
 
   /* Brand families */
-  --primary: #65942D; /* Olive Drab */
+  --primary: #4A6C21; /* deep olive for better contrast */
   --primary-foreground: #FFFFFF;
-  --primary-hover: #4A6C21; /* darker */
+  --primary-hover: #3A5218; /* darker */
   --primary-light: #98CC5A; /* lighter */
 
   --secondary: #188387; /* Teal */


### PR DESCRIPTION
## Summary
- darken light theme primary color for better text contrast
- document deeper olive primary for Arabic readability

## Testing
- `npm run lint`
- `npm run contrast:test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e8cc50c83289a13e7566edb060e