### PR TITLE
refactor: improve archive file cards

### DIFF
--- a/frontend/src/components/Archives/ArchiveCard.jsx
+++ b/frontend/src/components/Archives/ArchiveCard.jsx
@@ -1,0 +1,42 @@
+import { FileText } from 'lucide-react';
+import API_CONFIG from '@/config/config';
+
+export default function ArchiveCard({ file, onPreview }) {
+  const handlePreview = () => {
+    if (onPreview) onPreview(file);
+  };
+
+  return (
+    <div className="p-4 border rounded bg-white shadow-sm space-y-2">
+      <div className="flex items-center gap-3">
+        <FileText className="text-red-500 w-6 h-6" />
+        <div className="flex-1">
+          <h3 className="text-blue-600 font-semibold truncate">{file.number || 'بدون رقم'}</h3>
+          <h4 className="text-blue-600 font-semibold truncate">{file.title || 'بدون عنوان'}</h4>
+          <p className="text-xs text-gray-500 truncate">{file.extracted_text?.slice(0, 60) || 'لا يوجد نص'}</p>
+        </div>
+        {file.file_type && (
+          <span className="text-[10px] text-gray-500 border px-1 rounded">
+            {file.file_type}
+          </span>
+        )}
+      </div>
+      {file.file_path && (
+        <p className="text-[10px] text-gray-400 truncate">{file.file_path}</p>
+      )}
+      <div className="flex justify-between text-sm">
+        <button onClick={handlePreview} className="text-green-600 hover:underline">
+          معاينة
+        </button>
+        <a
+          href={`${API_CONFIG.baseURL}/storage/${file.file_path}`}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          تحميل
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ArchivePage.jsx
+++ b/frontend/src/pages/ArchivePage.jsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState ,lazy,Suspense} from 'react';
 
 import { getArchiveFiles } from '@/services/api/archives';
 import { toast } from 'sonner';
-import { FolderKanban, FolderOpenDot, ChevronsDown, ChevronsLeft, FileText } from 'lucide-react';
+import { FolderKanban, FolderOpenDot, ChevronsDown, ChevronsLeft } from 'lucide-react';
 import API_CONFIG from '@/config/config';
 import { ArchiveSection } from '@/assets/icons';
+import ArchiveCard from '@/components/Archives/ArchiveCard';
 
 const SectionHeader = lazy(() => import('@/components/common/SectionHeader'));
 const PDFViewer = lazy(() => import('@/components/PDFViewer'));
@@ -63,24 +64,7 @@ export default function ArchivePage() {
             {openFolders[type] && (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-2">
                 {files.map((file) => (
-                  <div key={file.id} className="p-4 border rounded bg-white shadow-sm space-y-2">
-                    <div className="flex items-center gap-3">
-                      <FileText className="text-red-500 w-6 h-6" />
-                      <div className="flex-1">
-                        <h3 className="text-blue-600 font-semibold truncate">{file.number || 'بدون رقم'}</h3>
-                        <h4 className="text-blue-600 font-semibold truncate">{file.title || 'بدون عنوان'}</h4>
-                        <p className="text-xs text-gray-500 truncate">{file.extracted_text?.slice(0, 60) || 'لا يوجد نص'}</p>
-                      </div>
-                    </div>
-                    <div className="flex justify-between text-sm">
-                      <button onClick={() => handlePdfPreview(file)} className="text-green-600 hover:underline">
-                        معاينة
-                      </button>
-                      <a href={`${API_CONFIG.baseURL}/storage/${file.file_path}`} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">
-                        تحميل
-                      </a>
-                    </div>
-                  </div>
+                  <ArchiveCard key={file.id} file={file} onPreview={handlePdfPreview} />
                 ))}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add reusable `ArchiveCard` component with file type and path details
- render archive files using cards for a cleaner layout

## Testing
- `npm run lint`
- `./vendor/bin/phpunit` *(fails: Tests: 2, Assertions: 1, Errors: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aa46cae61c83288a62d6ec401642fc