### PR TITLE
feat: add smart legal dashboard components

### DIFF
--- a/frontend/src/components/dashboard/CasesTrendChart.jsx
+++ b/frontend/src/components/dashboard/CasesTrendChart.jsx
@@ -1,0 +1,51 @@
+/**
+ * CasesTrendChart.jsx
+ * Stacked area chart of cases trend by status.
+ *
+ * i18n keys: 'dashboard.trend', 'dashboard.new', 'dashboard.inProgress', 'dashboard.closed'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+
+/**
+ * @typedef {{ month: string, new: number, inProgress: number, closed: number }} TrendPoint
+ */
+
+/**
+ * @param {{ data: TrendPoint[] }} props
+ */
+export default function CasesTrendChart({ data }) {
+  const { t } = useTranslation();
+  return (
+    <div className="bg-card rounded-2xl shadow-lg border border-border p-4" aria-label={t('dashboard.trend')}>
+      <ResponsiveContainer width="100%" height={260}>
+        <AreaChart data={data} margin={{ left: 0, right: 0 }}>
+          <defs>
+            <linearGradient id="new" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="5%" stopColor="rgb(var(--primary))" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="rgb(var(--primary))" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="inProgress" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="5%" stopColor="rgb(var(--secondary))" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="rgb(var(--secondary))" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="closed" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="5%" stopColor="rgb(var(--accent))" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="rgb(var(--accent))" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis dataKey="month" tickFormatter={(m) => m.slice(5)} />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Area type="monotone" dataKey="new" stackId="1" stroke="rgb(var(--primary))" fill="url(#new)" />
+          <Area type="monotone" dataKey="inProgress" stackId="1" stroke="rgb(var(--secondary))" fill="url(#inProgress)" />
+          <Area type="monotone" dataKey="closed" stackId="1" stroke="rgb(var(--accent))" fill="url(#closed)" />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export { type TrendPoint };

--- a/frontend/src/components/dashboard/EmptyStates.jsx
+++ b/frontend/src/components/dashboard/EmptyStates.jsx
@@ -1,0 +1,20 @@
+/**
+ * Empty states for dashboard widgets.
+ * i18n keys: 'dashboard.noData', 'dashboard.noResults'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card } from '@/components/ui/card';
+
+export function NoData() {
+  const { t } = useTranslation();
+  return (
+    <Card className="p-8 text-center">{t('dashboard.noData')}</Card>
+  );
+}
+
+export function NoResults() {
+  const { t } = useTranslation();
+  return <Card className="p-8 text-center">{t('dashboard.noResults')}</Card>;
+}
+

--- a/frontend/src/components/dashboard/ErrorBoundary.jsx
+++ b/frontend/src/components/dashboard/ErrorBoundary.jsx
@@ -1,0 +1,37 @@
+/**
+ * ErrorBoundary.jsx
+ * Catches errors per widget.
+ * i18n keys: 'dashboard.error', 'dashboard.retry'
+ */
+
+import { Component } from 'react';
+import { Button } from '@/components/ui/button';
+import { withTranslation } from 'react-i18next';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  handleRetry = () => {
+    this.setState({ hasError: false });
+    this.props.onRetry?.();
+  };
+  render() {
+    const { t } = this.props;
+    if (this.state.hasError) {
+      return (
+        <div className="p-6 text-center space-y-4">
+          <p>{t('dashboard.error')}</p>
+          <Button onClick={this.handleRetry}>{t('dashboard.retry')}</Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default withTranslation()(ErrorBoundary);

--- a/frontend/src/components/dashboard/FiltersBar.jsx
+++ b/frontend/src/components/dashboard/FiltersBar.jsx
@@ -1,0 +1,54 @@
+/**
+ * FiltersBar.jsx
+ * Sticky filters row.
+ * i18n keys: 'dashboard.filters', 'dashboard.dateRange', 'dashboard.team', 'dashboard.entity',
+ * 'dashboard.status', 'dashboard.court'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card } from '@/components/ui/card';
+import { Select, SelectTrigger, SelectContent, SelectItem } from '@/components/ui/select';
+
+/**
+ * @param {{ onChange?: (f:Record<string,any>)=>void }} props
+ */
+export default function FiltersBar({ onChange }) {
+  const { t } = useTranslation();
+  const handle = (field) => (value) => onChange?.({ [field]: value });
+  return (
+    <Card className="sticky top-16 z-30 backdrop-blur border border-border rounded-2xl p-2 flex flex-wrap gap-2">
+      <Select onValueChange={handle('range')}>
+        <SelectTrigger className="w-32">{t('dashboard.dateRange')}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="30">30</SelectItem>
+          <SelectItem value="90">90</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select onValueChange={handle('team')}>
+        <SelectTrigger className="w-32">{t('dashboard.team')}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t('dashboard.all')}</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select onValueChange={handle('entity')}>
+        <SelectTrigger className="w-32">{t('dashboard.entity')}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t('dashboard.all')}</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select onValueChange={handle('status')}>
+        <SelectTrigger className="w-32">{t('dashboard.status')}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="open">{t('dashboard.open')}</SelectItem>
+          <SelectItem value="closed">{t('dashboard.closed')}</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select onValueChange={handle('court')}>
+        <SelectTrigger className="w-32">{t('dashboard.court')}</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t('dashboard.all')}</SelectItem>
+        </SelectContent>
+      </Select>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/HeaderBar.jsx
+++ b/frontend/src/components/dashboard/HeaderBar.jsx
@@ -1,0 +1,56 @@
+/**
+ * HeaderBar.jsx
+ * Top navigation bar with search, theme toggle, direction toggle and user menu.
+ *
+ * i18n keys:
+ * 'dashboard.search', 'dashboard.toggleTheme', 'dashboard.toggleDir',
+ * 'dashboard.notifications', 'dashboard.profile', 'dashboard.logout'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Search, Bell, Languages, SunMoon, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+
+/**
+ * @param {{ user: { name: string }, onThemeToggle?: () => void, onDirToggle?: () => void }} props
+ */
+export default function HeaderBar({ user, onThemeToggle, onDirToggle }) {
+  const { t } = useTranslation();
+  return (
+    <header className="flex items-center justify-between gap-4">{/* breadcrumb slot left intentionally empty */}
+      <div className="flex-1 max-w-xs relative">
+        <Search className="absolute top-2 ms-2 h-4 w-4 text-muted" />
+        <Input
+          type="search"
+          placeholder={t('dashboard.search')}
+          className="ps-8"
+          aria-label={t('dashboard.search')}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="icon" onClick={onThemeToggle} aria-label={t('dashboard.toggleTheme')}>
+          <SunMoon className="h-5 w-5" />
+        </Button>
+        <Button variant="ghost" size="icon" onClick={onDirToggle} aria-label={t('dashboard.toggleDir')}>
+          <Languages className="h-5 w-5" />
+        </Button>
+        <Button variant="ghost" size="icon" aria-label={t('dashboard.notifications')}>
+          <Bell className="h-5 w-5" />
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label={user?.name}>
+              <User className="h-5 w-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem>{t('dashboard.profile')}</DropdownMenuItem>
+            <DropdownMenuItem>{t('dashboard.logout')}</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/dashboard/HomeDashboard.jsx
+++ b/frontend/src/components/dashboard/HomeDashboard.jsx
@@ -1,0 +1,183 @@
+/**
+ * HomeDashboard.jsx
+ *
+ * Composition shell for the legal case management dashboard.
+ * Pass data via props and wire callbacks for filters and quick actions.
+ *
+ * i18n keys used here and in child components:
+ * 'dashboard.title', 'dashboard.cases', 'dashboard.openTasks', 'dashboard.hearings',
+ * 'dashboard.slaBreaches', 'dashboard.recoveryEgp', 'dashboard.trend',
+ * 'dashboard.onTime', 'dashboard.breached', 'dashboard.workload',
+ * 'dashboard.upcomingHearings', 'dashboard.tasks', 'dashboard.recentActivity',
+ * 'dashboard.quickActions'
+ */
+
+import { useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import HeaderBar from './HeaderBar';
+import FiltersBar from './FiltersBar';
+import MetricCards from './MetricCards';
+import CasesTrendChart from './CasesTrendChart';
+import SLADonut from './SLADonut';
+import WorkloadHeatmap from './WorkloadHeatmap';
+import UpcomingHearings from './UpcomingHearings';
+import TasksKanban from './TasksKanban';
+import RecentActivity from './RecentActivity';
+import QuickActions from './QuickActions';
+import ErrorBoundary from './ErrorBoundary';
+import { DashboardLoader } from './Loaders';
+import { NoData } from './EmptyStates';
+
+/**
+ * Number formatter for EGP currency.
+ * @param {number} value
+ * @returns {string}
+ */
+const formatEGP = (value) =>
+  new Intl.NumberFormat('en-EG', { style: 'currency', currency: 'EGP', maximumFractionDigits: 0 }).format(value);
+
+/**
+ * @typedef {Object} HomeDashboardProps
+ * @property {import('./MetricCards').KPIData} kpis
+ * @property {import('./CasesTrendChart').TrendPoint[]} trend
+ * @property {{ onTime: number, breached: number }} sla
+ * @property {import('./WorkloadHeatmap').WorkloadPoint[]} workload
+ * @property {import('./UpcomingHearings').Hearing[]} hearings
+ * @property {import('./TasksKanban').KanbanData} kanban
+ * @property {import('./RecentActivity').ActivityItem[]} activity
+ * @property {{ id: string, name: string, role: string, permissions: string[] }} user
+ * @property {(filters: Record<string, any>) => void} onFilterChange
+ * @property {(action: string) => void} onQuickAction
+ */
+
+/**
+ * @param {HomeDashboardProps} props
+ */
+export default function HomeDashboard(props) {
+  const { t } = useTranslation();
+  const {
+    kpis,
+    trend,
+    sla,
+    workload,
+    hearings,
+    kanban,
+    activity,
+    user,
+    onFilterChange,
+    onQuickAction,
+  } = props;
+
+  // keyboard shortcuts
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 't') {
+        document.documentElement.classList.toggle('dark');
+      }
+      if (e.key === 'l') {
+        const dir = document.documentElement.getAttribute('dir') === 'rtl' ? 'ltr' : 'rtl';
+        document.documentElement.setAttribute('dir', dir);
+      }
+      if (e.key === '?') {
+        // placeholder for shortcuts dialog
+        alert(t('dashboard.shortcuts'));
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [t]);
+
+  const handleFilterChange = useCallback(
+    (filters) => {
+      onFilterChange?.(filters);
+    },
+    [onFilterChange]
+  );
+
+  return (
+    <main className="space-y-6">
+      <HeaderBar user={user} />
+      <FiltersBar onChange={handleFilterChange} />
+      <QuickActions user={user} onAction={onQuickAction} />
+      <ErrorBoundary fallback={<NoData />}> {
+        kpis ? <MetricCards kpis={kpis} formatter={formatEGP} /> : <DashboardLoader />
+      } </ErrorBoundary>
+      <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
+        <div className="xl:col-span-8">
+          <ErrorBoundary fallback={<NoData />}>
+            {trend ? <CasesTrendChart data={trend} /> : <DashboardLoader />}
+          </ErrorBoundary>
+        </div>
+        <div className="xl:col-span-4">
+          <ErrorBoundary fallback={<NoData />}>
+            {sla ? <SLADonut data={sla} /> : <DashboardLoader />}
+          </ErrorBoundary>
+        </div>
+      </div>
+      <ErrorBoundary fallback={<NoData />}>
+        {workload ? <WorkloadHeatmap data={workload} /> : <DashboardLoader />}
+      </ErrorBoundary>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <ErrorBoundary fallback={<NoData />}>
+          {hearings ? <UpcomingHearings items={hearings} /> : <DashboardLoader />}
+        </ErrorBoundary>
+        <ErrorBoundary fallback={<NoData />}>
+          {kanban ? <TasksKanban data={kanban} /> : <DashboardLoader />}
+        </ErrorBoundary>
+        <ErrorBoundary fallback={<NoData />}>
+          {activity ? <RecentActivity items={activity} /> : <DashboardLoader />}
+        </ErrorBoundary>
+      </div>
+    </main>
+  );
+}
+
+export const mocks = import.meta.env?.DEV
+  ? {
+      kpis: {
+        cases: { total: 128, deltaPct: 6.4, spark: [4, 6, 5, 8, 9, 11, 10] },
+        tasks: { total: 59, deltaPct: -3.2, spark: [8, 7, 6, 5, 6, 7, 6] },
+        hearings: { total: 12, deltaPct: 2.1, spark: [1, 1, 2, 3, 2, 2, 1] },
+        breaches: { total: 5, deltaPct: -1.1, spark: [1, 0, 1, 1, 1, 1, 0] },
+        recoveryEgp: { total: 2350000, deltaPct: 4.9, spark: [200, 220, 210, 240, 250, 260, 270] },
+      },
+      trend: [
+        { month: '2024-09', new: 10, inProgress: 24, closed: 6 },
+        { month: '2024-10', new: 12, inProgress: 20, closed: 8 },
+        { month: '2024-11', new: 14, inProgress: 22, closed: 10 },
+        { month: '2024-12', new: 13, inProgress: 18, closed: 12 },
+        { month: '2025-01', new: 16, inProgress: 17, closed: 11 },
+        { month: '2025-02', new: 19, inProgress: 15, closed: 12 },
+        { month: '2025-03', new: 17, inProgress: 20, closed: 14 },
+        { month: '2025-04', new: 15, inProgress: 21, closed: 16 },
+        { month: '2025-05', new: 20, inProgress: 23, closed: 18 },
+        { month: '2025-06', new: 22, inProgress: 25, closed: 19 },
+        { month: '2025-07', new: 21, inProgress: 24, closed: 20 },
+        { month: '2025-08', new: 23, inProgress: 26, closed: 21 },
+      ],
+      sla: { onTime: 91, breached: 9 },
+      workload: [
+        { weekday: 0, slot: 'AM', value: 3 },
+        { weekday: 1, slot: 'PM', value: 5 },
+      ],
+      hearings: [
+        {
+          id: 'h1',
+          date: '2025-09-02T08:00:00Z',
+          court: 'Giza Court',
+          room: '12B',
+          caseNo: '2025/413',
+          client: 'Al-Nour Co.',
+        },
+      ],
+      kanban: { todo: [{ id: 't1', title: 'Draft filing', assignee: 'Mona' }], doing: [], waiting: [], done: [] },
+      activity: [
+        {
+          id: 'a1',
+          ts: '2025-08-18T09:22:00Z',
+          type: 'filing',
+          title: 'Filed appeal for Case 2025/413',
+        },
+      ],
+    }
+  : undefined;

--- a/frontend/src/components/dashboard/Loaders.jsx
+++ b/frontend/src/components/dashboard/Loaders.jsx
@@ -1,0 +1,18 @@
+/**
+ * Skeleton loaders for dashboard sections.
+ */
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DashboardLoader() {
+  return (
+    <Card className="rounded-2xl border border-border shadow-lg">
+      <CardContent className="p-6 space-y-4">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-8 w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/frontend/src/components/dashboard/MetricCards.jsx
+++ b/frontend/src/components/dashboard/MetricCards.jsx
@@ -1,0 +1,81 @@
+/**
+ * MetricCards.jsx
+ * Grid of KPI cards with spark lines and delta badges.
+ *
+ * i18n keys:
+ * 'dashboard.cases', 'dashboard.openTasks', 'dashboard.hearings',
+ * 'dashboard.slaBreaches', 'dashboard.recoveryEgp'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ResponsiveContainer, AreaChart, Area } from 'recharts';
+import { motion } from 'framer-motion';
+
+/**
+ * @typedef {Object} CaseKPI
+ * @property {number} total
+ * @property {number} deltaPct
+ * @property {number[]} spark
+ */
+
+/**
+ * @typedef {Object} KPIData
+ * @property {CaseKPI} cases
+ * @property {CaseKPI} tasks
+ * @property {CaseKPI} hearings
+ * @property {CaseKPI} breaches
+ * @property {CaseKPI} recoveryEgp
+ */
+
+/**
+ * @param {{ kpis: KPIData, formatter?: (n:number)=>string }} props
+ */
+export default function MetricCards({ kpis, formatter }) {
+  const { t } = useTranslation();
+  const cards = [
+    { key: 'cases', label: t('dashboard.cases') },
+    { key: 'tasks', label: t('dashboard.openTasks') },
+    { key: 'hearings', label: t('dashboard.hearings') },
+    { key: 'breaches', label: t('dashboard.slaBreaches') },
+    { key: 'recoveryEgp', label: t('dashboard.recoveryEgp'), format: formatter },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
+      {cards.map(({ key, label, format }) => {
+        const kpi = kpis[key];
+        const deltaColor = kpi.deltaPct >= 0 ? 'success' : 'destructive';
+        return (
+          <motion.div key={key} whileHover={{ y: -4 }}>
+            <Card className="bg-card shadow-lg border border-border rounded-2xl">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">{label}</CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="flex items-center justify-between">
+                  <div className="text-2xl font-heading">
+                    {format ? format(kpi.total) : kpi.total}
+                  </div>
+                  <Badge variant={deltaColor}>
+                    {kpi.deltaPct}%
+                  </Badge>
+                </div>
+                <div className="h-12">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={kpi.spark.map((v, i) => ({ v, i }))}>
+                      <Area type="monotone" dataKey="v" stroke="rgb(var(--primary))" fill="rgba(var(--primary)/0.2)" />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}
+
+export { type CaseKPI, type KPIData };

--- a/frontend/src/components/dashboard/QuickActions.jsx
+++ b/frontend/src/components/dashboard/QuickActions.jsx
@@ -1,0 +1,39 @@
+/**
+ * QuickActions.jsx
+ * Action buttons for common operations.
+ * i18n keys: 'dashboard.quickActions', 'dashboard.newCase', 'dashboard.newContract',
+ * 'dashboard.export', 'dashboard.bulkUpdate', 'dashboard.summarize'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { PlusCircle, FilePlus2, Download, RefreshCw, Sparkles } from 'lucide-react';
+
+/**
+ * @param {{ user: { permissions: string[] }, onAction?: (a:string)=>void }} props
+ */
+export default function QuickActions({ user, onAction }) {
+  const { t } = useTranslation();
+  const actions = [
+    { key: 'new-case', label: t('dashboard.newCase'), icon: PlusCircle, perm: 'case:create' },
+    { key: 'new-contract', label: t('dashboard.newContract'), icon: FilePlus2, perm: 'contract:create' },
+    { key: 'export', label: t('dashboard.export'), icon: Download, perm: 'export' },
+    { key: 'bulk', label: t('dashboard.bulkUpdate'), icon: RefreshCw, perm: 'bulk:update' },
+    { key: 'ai', label: t('dashboard.summarize'), icon: Sparkles, perm: 'ai', disabled: true },
+  ];
+  return (
+    <div className="flex flex-wrap gap-2" aria-label={t('dashboard.quickActions')}>
+      {actions.map((a) => (
+        <Button
+          key={a.key}
+          onClick={() => onAction?.(a.key)}
+          disabled={a.disabled || !user.permissions.includes(a.perm)}
+          variant="secondary"
+          className="flex items-center gap-1"
+        >
+          <a.icon className="h-4 w-4" /> {a.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RecentActivity.jsx
+++ b/frontend/src/components/dashboard/RecentActivity.jsx
@@ -1,0 +1,54 @@
+/**
+ * RecentActivity.jsx
+ * Timeline feed with icons & relative time.
+ * i18n keys: 'dashboard.recentActivity'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { FileText, Gavel, MessageSquare, CheckSquare } from 'lucide-react';
+
+/**
+ * @typedef {{ id: string, ts: string, type: 'hearing'|'filing'|'note'|'task', title: string, meta?: string }} ActivityItem
+ */
+
+const typeIcon = {
+  hearing: Gavel,
+  filing: FileText,
+  note: MessageSquare,
+  task: CheckSquare,
+};
+
+/**
+ * @param {{ items: ActivityItem[] }} props
+ */
+export default function RecentActivity({ items }) {
+  const { t } = useTranslation();
+  return (
+    <Card className="bg-card shadow-lg border border-border rounded-2xl">
+      <CardHeader>
+        <CardTitle className="font-heading tracking-tight text-lg">{t('dashboard.recentActivity')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-4">
+          {items.map((a) => {
+            const Icon = typeIcon[a.type];
+            return (
+              <li key={a.id} className="flex items-start gap-3">
+                <Icon className="h-4 w-4 mt-1 text-muted" />
+                <div>
+                  <div className="font-medium">{a.title}</div>
+                  <time className="text-sm text-muted" dateTime={a.ts}>
+                    {new Date(a.ts).toLocaleString()}
+                  </time>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export { type ActivityItem };

--- a/frontend/src/components/dashboard/SLADonut.jsx
+++ b/frontend/src/components/dashboard/SLADonut.jsx
@@ -1,0 +1,33 @@
+/**
+ * SLADonut.jsx
+ * Donut chart for SLA performance.
+ * i18n keys: 'dashboard.onTime', 'dashboard.breached'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+
+/**
+ * @param {{ data: { onTime: number, breached: number } }} props
+ */
+export default function SLADonut({ data }) {
+  const { t } = useTranslation();
+  const chartData = [
+    { name: t('dashboard.onTime'), value: data.onTime, color: 'rgb(var(--success))' },
+    { name: t('dashboard.breached'), value: data.breached, color: 'rgb(var(--destructive))' },
+  ];
+  return (
+    <div className="bg-card rounded-2xl shadow-lg border border-border p-4" aria-label={t('dashboard.sla')}>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie data={chartData} dataKey="value" innerRadius={60} outerRadius={100} stroke="none">
+            {chartData.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/TasksKanban.jsx
+++ b/frontend/src/components/dashboard/TasksKanban.jsx
@@ -1,0 +1,46 @@
+/**
+ * TasksKanban.jsx
+ * Compact Kanban board.
+ * i18n keys: 'dashboard.tasks', 'dashboard.todo', 'dashboard.inProgress', 'dashboard.waiting', 'dashboard.done'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * @typedef {{ id: string, title: string, assignee?: string }} Task
+ * @typedef {{ todo: Task[], doing: Task[], waiting: Task[], done: Task[] }} KanbanData
+ */
+
+/**
+ * @param {{ data: KanbanData }} props
+ */
+export default function TasksKanban({ data }) {
+  const { t } = useTranslation();
+  const columns = [
+    { key: 'todo', label: t('dashboard.todo') },
+    { key: 'doing', label: t('dashboard.inProgress') },
+    { key: 'waiting', label: t('dashboard.waiting') },
+    { key: 'done', label: t('dashboard.done') },
+  ];
+  return (
+    <Card className="bg-card shadow-lg border border-border rounded-2xl">
+      <CardHeader>
+        <CardTitle className="font-heading tracking-tight text-lg">{t('dashboard.tasks')}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-2 text-sm">
+        {columns.map((col) => (
+          <div key={col.key} className="space-y-2">
+            <div className="font-medium">{col.label}</div>
+            {data[col.key].map((task) => (
+              <div key={task.id} className={cn('p-2 rounded bg-muted/20')}>{task.title}</div>
+            ))}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export { type Task, type KanbanData };

--- a/frontend/src/components/dashboard/UpcomingHearings.jsx
+++ b/frontend/src/components/dashboard/UpcomingHearings.jsx
@@ -1,0 +1,51 @@
+/**
+ * UpcomingHearings.jsx
+ * List of upcoming hearings.
+ * i18n keys: 'dashboard.upcomingHearings'
+ */
+
+import { useTranslation } from 'react-i18next';
+import { CalendarDays, Landmark } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+/**
+ * @typedef {{ id: string, date: string, court: string, room?: string, caseNo: string, client: string }} Hearing
+ */
+
+/**
+ * @param {{ items: Hearing[] }} props
+ */
+export default function UpcomingHearings({ items }) {
+  const { t } = useTranslation();
+  return (
+    <Card className="bg-card shadow-lg border border-border rounded-2xl">
+      <CardHeader>
+        <CardTitle className="font-heading tracking-tight text-lg">
+          {t('dashboard.upcomingHearings')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-4">
+          {items.map((h) => (
+            <li key={h.id} className="flex items-center gap-3">
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <CalendarDays className="h-4 w-4" />
+                {new Date(h.date).toLocaleDateString()}
+              </Badge>
+              <div className="flex-1">
+                <div className="font-medium">{h.caseNo}</div>
+                <div className="text-sm text-muted">
+                  {h.client} – {h.court} {h.room}
+                </div>
+              </div>
+              <Landmark className="h-4 w-4 text-muted" />
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export { type Hearing };

--- a/frontend/src/components/dashboard/WorkloadHeatmap.jsx
+++ b/frontend/src/components/dashboard/WorkloadHeatmap.jsx
@@ -1,0 +1,59 @@
+/**
+ * WorkloadHeatmap.jsx
+ * Weekly workload heatmap (Mon-Sun x AM/PM/EV).
+ * i18n keys: 'dashboard.workload'
+ */
+
+import { Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+
+/**
+ * @typedef {{ weekday: number, slot: 'AM'|'PM'|'EV', value: number }} WorkloadPoint
+ */
+
+const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const slots = ['AM', 'PM', 'EV'];
+
+/**
+ * @param {{ data: WorkloadPoint[] }} props
+ */
+export default function WorkloadHeatmap({ data }) {
+  const { t } = useTranslation();
+  const grid = Array.from({ length: 7 }, () => ({ AM: 0, PM: 0, EV: 0 }));
+  data.forEach(({ weekday, slot, value }) => {
+    grid[weekday][slot] = value;
+  });
+
+  return (
+    <section className="bg-card rounded-2xl shadow-lg border border-border p-4" aria-label={t('dashboard.workload')}>
+      <div className="grid grid-cols-8 gap-1 text-center">
+        <div></div>
+        {weekdays.map((d) => (
+          <div key={d} className="text-xs font-medium">
+            {d}
+          </div>
+        ))}
+        {slots.map((slot) => (
+          <Fragment key={slot}>
+            <div className="text-xs font-medium self-center">{slot}</div>
+            {grid.map((col, i) => {
+              const val = col[slot];
+              const intensity = val / 10 + 0.1;
+              return (
+                <div
+                  key={`${slot}-${i}`}
+                  className={cn('w-full aspect-square rounded', 'bg-primary')}
+                  style={{ opacity: intensity }}
+                  title={`${weekdays[i]} ${slot}: ${val}`}
+                />
+              );
+            })}
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export { type WorkloadPoint };

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,138 +1,57 @@
-@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&display=swap');
- 
+@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  /* Typography */
-  --font-body: 'Cairo', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
-  --font-heading: 'Inter', 'Cairo', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  /* Base */
+  --background: 255 255 255;
+  --foreground: 17 24 39;
 
-  /* Core surfaces & text */
-  --background: #FFFFFF;
-  --foreground: #444444; /* Charcoal */
-  --muted: #E6F2FA;      /* Light Blue Tint */
-  --muted-foreground: #3F4A56;
+  /* Brand */
+  --primary: 60 64 198;
+  --primary-foreground: 255 255 255;
 
-  --border: #E5E7EB; /* gray-200 */
-  --input: #D1D5DB;  /* gray-300 */
-  --ring: #2A8DD4;   /* Accent */
+  --secondary: 5 150 160;
+  --secondary-foreground: 255 255 255;
 
-  /* Brand families */
-  --primary: #4A6C21; /* deep olive for better contrast */
-  --primary-foreground: #FFFFFF;
-  --primary-hover: #3A5218; /* darker */
-  --primary-light: #98CC5A; /* lighter */
+  --accent: 99 102 241;
+  --muted: 107 114 128;
 
-  --secondary: #188387; /* Teal */
-  --secondary-foreground: #FFFFFF;
-  --secondary-hover: #10585B; /* darker */
-  --secondary-light: #1FADB2; /* lighter */
-
-  --accent: #2A8DD4; /* Medium Blue */
-  --accent-foreground: #FFFFFF;
-  --accent-hover: #2170A9; /* darker */
-  --accent-light: #53A3DD; /* lighter */
-
-  /* State colors */
-  --success: #98CC5A;
-  --success-foreground: #0F2A0F;
-
-  --warning: #F5C242;
-  --warning-foreground: #3A2A00;
-
-  --destructive: #B03035;
-  --destructive-foreground: #FFFFFF;
+  /* Status */
+  --success: 16 185 129;
+  --warning: 245 158 11;
+  --destructive: 239 68 68;
 
   /* Surfaces */
-  --card: #FFFFFF;
-  --card-foreground: #444444;
-  --card-hover: #F8FAFC;
+  --card: 255 255 255;
+  --card-foreground: 17 24 39;
+  --popover: 255 255 255;
+  --border: 229 231 235;
+  --ring: 60 64 198;
 
-  --popover: #FFFFFF;
-  --popover-foreground: #2B2B2B;
-
-  /* Sidebar suite */
-  --sidebar: #F7FAF6; /* very light olive-tinted */
-  --sidebar-foreground: #2F4515; /* dark olive text */
-  --sidebar-accent: #98CC5A;
-  --sidebar-accent-foreground: #0F2A0F;
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-border: #E5E7EB;
-  --sidebar-ring: var(--ring);
+  /* Sidebar */
+  --sidebar: 17 24 39;
+  --sidebar-foreground: 229 231 235;
+  --sidebar-muted: 100 116 139;
 
   /* Gradients */
-  --gradient-primary: linear-gradient(135deg, #65942D 0%, #188387 100%);
-  --gradient-secondary: linear-gradient(135deg, #2A8DD4 0%, #188387 100%);
-  --gradient-hero: linear-gradient(135deg, #E6F2FA 0%, #FFFFFF 100%);
-  --gradient-card: linear-gradient(180deg, #FFFFFF 0%, #F7FAF6 100%);
+  --gradient-primary: linear-gradient(135deg, rgb(60 64 198) 0%, rgb(99 102 241) 100%);
+  --gradient-card: linear-gradient(180deg, rgba(60 64 198/0.08) 0%, rgba(99 102 241/0.02) 100%);
 
-  /* Shadows (tokenized) */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.06);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 10px 10px -5px rgb(0 0 0 / 0.1);
-  --shadow-glow: 0 0 0 3px #2A8DD433; /* ring glow using accent */
+  /* Shadows */
+  --shadow-lg: 0 10px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+
+  /* Fonts */
+  --font-heading: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  --font-body: "Cairo", system-ui, -apple-system, Segoe UI, Roboto, Arial;
 }
 
 .dark {
-  --background: #0E1A17;          /* deep teal-black */
-  --foreground: #E5E7EB;          /* gray-200 */
-  --muted: #0F2A2D;               /* deep muted teal */
-  --muted-foreground: #A3B1BF;    /* soft slate */
-
-  --border: #1F2A2D;
-  --input: #2A3A3D;
-  --ring: #53A3DD; /* brighter accent in dark */
-
-  --card: #0F2123;                /* close to #082E30 */
-  --card-foreground: #E5E7EB;
-  --card-hover: #153336;
-
-  --popover: #0F2123;
-  --popover-foreground: #E5E7EB;
-
-  /* Brands keep contrast‑safe variants */
-  --primary: #98CC5A;             /* use lighter primary for dark surfaces */
-  --primary-foreground: #0F2A0F;
-  --primary-hover: #7FBB38;
-  --primary-light: #B0D881;
-
-  --secondary: #1FADB2;           /* lighter teal for dark */
-  --secondary-foreground: #082E30;
-  --secondary-hover: #2BD3D9;
-  --secondary-light: #53DCE1;
-
-  --accent: #53A3DD;              /* lighter accent for dark */
-  --accent-foreground: #0C2235;
-  --accent-hover: #7EBAE5;
-  --accent-light: #A9D2F0;
-
-  --success: #A7D67A;
-  --success-foreground: #0E2410;
-
-  --warning: #F6CA5A;
-  --warning-foreground: #2A1F00;
-
-  --destructive: #C23A40;
-  --destructive-foreground: #FFFFFF;
-
-  --sidebar: #0F2123;
-  --sidebar-foreground: #DDE5D1;
-  --sidebar-accent: #4A6C21; /* darker olive for active */
-  --sidebar-accent-foreground: #FFFFFF;
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-border: #1F2A2D;
-  --sidebar-ring: var(--ring);
-
-  --gradient-primary: linear-gradient(135deg, #10585B 0%, #98CC5A 100%);
-  --gradient-secondary: linear-gradient(135deg, #2170A9 0%, #1FADB2 100%);
-  --gradient-hero: linear-gradient(135deg, #0E1A17 0%, #0F2123 100%);
-  --gradient-card: linear-gradient(180deg, #0F2123 0%, #0E1A17 100%);
-
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.35);
-  --shadow-md: 0 4px 8px 0 rgb(0 0 0 / 0.45);
-  --shadow-lg: 0 12px 20px 0 rgb(0 0 0 / 0.5);
-  --shadow-xl: 0 20px 35px 0 rgb(0 0 0 / 0.55);
-  --shadow-glow: 0 0 0 3px #53A3DD55; 
+  --background: 3 7 18;
+  --foreground: 243 244 246;
+  --card: 9 13 28;
+  --card-foreground: 243 244 246;
+  --popover: 9 13 28;
+  --border: 31 41 55;
+  --sidebar: 3 7 18;
+  --sidebar-foreground: 203 213 225;
+  --sidebar-muted: 100 116 139;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,99 +1,41 @@
 import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
+import rtl from 'tailwindcss-rtl';
 
 export default {
-  darkMode: ['class'],
-  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  darkMode: 'class',
+  content: ['index.html', 'src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    container: {
-      center: true,
-      padding: '1rem',
-      screens: { '2xl': '1280px' },
-    },
     extend: {
       colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
-        border: 'var(--border)',
-        input: 'var(--input)',
-        ring: 'var(--ring)',
-        primary: {
-          DEFAULT: 'var(--primary)',
-          foreground: 'var(--primary-foreground)',
-          hover: 'var(--primary-hover)',
-          light: 'var(--primary-light)',
-        },
-        secondary: {
-          DEFAULT: 'var(--secondary)',
-          foreground: 'var(--secondary-foreground)',
-          hover: 'var(--secondary-hover)',
-          light: 'var(--secondary-light)',
-        },
-        accent: {
-          DEFAULT: 'var(--accent)',
-          foreground: 'var(--accent-foreground)',
-          hover: 'var(--accent-hover)',
-          light: 'var(--accent-light)',
-        },
-        muted: {
-          DEFAULT: 'var(--muted)',
-          foreground: 'var(--muted-foreground)',
-        },
-        success: {
-          DEFAULT: 'var(--success)',
-          foreground: 'var(--success-foreground)',
-        },
-        warning: {
-          DEFAULT: 'var(--warning)',
-          foreground: 'var(--warning-foreground)',
-        },
-        destructive: {
-          DEFAULT: 'var(--destructive)',
-          foreground: 'var(--destructive-foreground)',
-        },
-        popover: {
-          DEFAULT: 'var(--popover)',
-          foreground: 'var(--popover-foreground)',
-        },
-        card: {
-          DEFAULT: 'var(--card)',
-          foreground: 'var(--card-foreground)',
-          hover: 'var(--card-hover)',
-        },
-        sidebar: { 
-          DEFAULT: 'var(--sidebar)',
-          foreground: 'var(--sidebar-foreground)',
-          primary: 'var(--sidebar-primary)',
-          'primary-foreground': 'var(--sidebar-primary-foreground)',
-          accent: 'var(--sidebar-accent)',
-          'accent-foreground': 'var(--sidebar-accent-foreground)',
-          border: 'var(--sidebar-border)',
-          ring: 'var(--sidebar-ring)',
- 
-        },
+        background: 'rgb(var(--background) / <alpha-value>)',
+        foreground: 'rgb(var(--foreground) / <alpha-value>)',
+        primary: 'rgb(var(--primary) / <alpha-value>)',
+        'primary-foreground': 'rgb(var(--primary-foreground) / <alpha-value>)',
+        secondary: 'rgb(var(--secondary) / <alpha-value>)',
+        accent: 'rgb(var(--accent) / <alpha-value>)',
+        muted: 'rgb(var(--muted) / <alpha-value>)',
+        success: 'rgb(var(--success) / <alpha-value>)',
+        warning: 'rgb(var(--warning) / <alpha-value>)',
+        destructive: 'rgb(var(--destructive) / <alpha-value>)',
+        card: 'rgb(var(--card) / <alpha-value>)',
+        'card-foreground': 'rgb(var(--card-foreground) / <alpha-value>)',
+        border: 'rgb(var(--border) / <alpha-value>)',
+        sidebar: 'rgb(var(--sidebar) / <alpha-value>)',
+        'sidebar-foreground': 'rgb(var(--sidebar-foreground) / <alpha-value>)',
+      },
+      boxShadow: {
+        lg: 'var(--shadow-lg)',
+      },
+      fontFamily: {
+        heading: 'var(--font-heading)',
+        body: 'var(--font-body)',
       },
       backgroundImage: {
         'gradient-primary': 'var(--gradient-primary)',
-        'gradient-secondary': 'var(--gradient-secondary)',
-        'gradient-hero': 'var(--gradient-hero)',
         'gradient-card': 'var(--gradient-card)',
-      },
-      boxShadow: {
-        sm: 'var(--shadow-sm)',
-        md: 'var(--shadow-md)',
-        lg: 'var(--shadow-lg)',
-        xl: 'var(--shadow-xl)',
-        glow: 'var(--shadow-glow)',
-      },
-      fontFamily: {
-        heading: ['var(--font-heading)'],
-        body: ['var(--font-body)'],
-      },
-      borderRadius: {
-        xl: '0.75rem',
-        '2xl': '1rem',
       },
     },
   },
-  plugins: [forms, typography],
+  plugins: [forms, typography, rtl],
 };


### PR DESCRIPTION
## Summary
- add dashboard widget components and composition shell
- map design tokens to Tailwind config and CSS variables
- provide skeleton loaders, empty states and error boundary

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abb6e9862c8328bffedf919f158eeb