### PR TITLE
feat: add neon dark theme and translate dashboard

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,6 +148,19 @@
     @apply bg-muted-foreground;
   }
 
+  /* Card styling */
+  .professional-card {
+    @apply bg-gradient-to-br from-card to-card-hover border border-border rounded-xl shadow-card transition-shadow;
+  }
+
+  .professional-card:hover {
+    @apply shadow-elegant;
+  }
+
+  .dark .professional-card {
+    @apply bg-gradient-to-br from-slate-800 via-slate-900 to-black shadow-neon;
+  }
+
   /* Animations */
   .animate-fade-in {
     animation: fadeIn 0.3s ease-in-out;

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -31,7 +31,23 @@
     "totalContracts": "إجمالي العقود",
     "activeCases": "القضايا النشطة",
     "pendingInvestigations": "التحقيقات المعلقة",
-    "legalAdviceRequests": "طلبات الاستشارة"
+    "legalAdviceRequests": "طلبات الاستشارة",
+    "subtitle": "نظرة عامة على أنشطة المنصة والإحصائيات",
+    "welcomeUser": "مرحباً، {{name}}",
+    "upcomingTasks": "المهام القادمة",
+    "viewAllActivities": "عرض جميع الأنشطة",
+    "viewAllTasks": "عرض جميع المهام",
+    "newContract": "عقد جديد",
+    "newAdvice": "استشارة جديدة",
+    "newInvestigation": "تحقيق جديد",
+    "newCase": "قضية جديدة",
+    "deadline": "الموعد النهائي",
+    "priority": {
+      "urgent": "عاجل",
+      "high": "مهم",
+      "medium": "متوسط",
+      "normal": "عادي"
+    }
   },
   "contracts": {
     "title": "إدارة العقود",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,7 +31,23 @@
     "totalContracts": "Total Contracts",
     "activeCases": "Active Cases",
     "pendingInvestigations": "Pending Investigations",
-    "legalAdviceRequests": "Legal Advice Requests"
+    "legalAdviceRequests": "Legal Advice Requests",
+    "subtitle": "Overview of platform activities and statistics",
+    "welcomeUser": "Welcome, {{name}}",
+    "upcomingTasks": "Upcoming Tasks",
+    "viewAllActivities": "View all activities",
+    "viewAllTasks": "View all tasks",
+    "newContract": "New Contract",
+    "newAdvice": "New Consultation",
+    "newInvestigation": "New Investigation",
+    "newCase": "New Case",
+    "deadline": "Deadline",
+    "priority": {
+      "urgent": "Urgent",
+      "high": "High",
+      "medium": "Medium",
+      "normal": "Normal"
+    }
   },
   "contracts": {
     "title": "Contract Management",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
   FileText,
@@ -48,10 +49,11 @@ interface Task {
 const DashboardPage: React.FC = () => {
   const { user } = useAuth();
   const { isRTL } = useLanguage();
+  const { t } = useTranslation();
 
   const stats: Stat[] = [
     {
-      title: 'إجمالي العقود',
+      title: t('dashboard.totalContracts'),
       value: '1,247',
       change: '+12%',
       icon: FileText,
@@ -59,7 +61,7 @@ const DashboardPage: React.FC = () => {
       bgColor: 'bg-blue-100',
     },
     {
-      title: 'الاستشارات القانونية',
+      title: t('dashboard.legalAdviceRequests'),
       value: '856',
       change: '+8%',
       icon: Scale,
@@ -67,7 +69,7 @@ const DashboardPage: React.FC = () => {
       bgColor: 'bg-green-100',
     },
     {
-      title: 'التحقيقات الجارية',
+      title: t('dashboard.pendingInvestigations'),
       value: '24',
       change: '-3%',
       icon: Search,
@@ -75,7 +77,7 @@ const DashboardPage: React.FC = () => {
       bgColor: 'bg-orange-100',
     },
     {
-      title: 'القضايا النشطة',
+      title: t('dashboard.activeCases'),
       value: '18',
       change: '+5%',
       icon: Gavel,
@@ -147,21 +149,21 @@ const DashboardPage: React.FC = () => {
 
   const getPriorityText = (priority: string) => {
     switch (priority) {
-      case 'urgent': return 'عاجل';
-      case 'high': return 'مهم';
-      case 'medium': return 'متوسط';
-      default: return 'عادي';
+      case 'urgent': return t('dashboard.priority.urgent');
+      case 'high': return t('dashboard.priority.high');
+      case 'medium': return t('dashboard.priority.medium');
+      default: return t('dashboard.priority.normal');
     }
   };
 
   return (
     <AppLayout>
       <div className="space-y-8">
-        <SectionHeader
-          title={`مرحباً، ${user?.name}`}
-          subtitle="نظرة عامة على أنشطة المنصة والإحصائيات"
-          icon={BarChart3}
-        />
+          <SectionHeader
+            title={t('dashboard.welcomeUser', { name: user?.name })}
+            subtitle={t('dashboard.subtitle')}
+            icon={BarChart3}
+          />
 
         {/* Statistics Cards */}
         <motion.div
@@ -217,7 +219,7 @@ const DashboardPage: React.FC = () => {
               <CardHeader>
                 <CardTitle className={`flex items-center space-x-2 ${isRTL ? 'space-x-reverse' : ''}`}>
                   <Clock className="w-5 h-5 text-primary" />
-                  <span>الأنشطة الأخيرة</span>
+                  <span>{t('dashboard.recentActivities')}</span>
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -251,7 +253,7 @@ const DashboardPage: React.FC = () => {
                 ))}
                 <div className="pt-4 border-t">
                   <Button variant="outline" className="w-full">
-                    عرض جميع الأنشطة
+                    {t('dashboard.viewAllActivities')}
                   </Button>
                 </div>
               </CardContent>
@@ -268,7 +270,7 @@ const DashboardPage: React.FC = () => {
               <CardHeader>
                 <CardTitle className={`flex items-center space-x-2 ${isRTL ? 'space-x-reverse' : ''}`}>
                   <Calendar className="w-5 h-5 text-primary" />
-                  <span>المهام القادمة</span>
+                  <span>{t('dashboard.upcomingTasks')}</span>
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -288,13 +290,13 @@ const DashboardPage: React.FC = () => {
                       </Badge>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      الموعد النهائي: {task.deadline}
+                      {t('dashboard.deadline')}: {task.deadline}
                     </p>
                   </motion.div>
                 ))}
                 <div className="pt-4 border-t">
                   <Button variant="outline" size="sm" className="w-full">
-                    عرض جميع المهام
+                    {t('dashboard.viewAllTasks')}
                   </Button>
                 </div>
               </CardContent>
@@ -310,29 +312,29 @@ const DashboardPage: React.FC = () => {
         >
           <Card className="professional-card">
             <CardHeader>
-              <CardTitle>إجراءات سريعة</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
-                  <FileText className="w-6 h-6" />
-                  <span className="text-sm">عقد جديد</span>
-                </Button>
-                <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
-                  <Scale className="w-6 h-6" />
-                  <span className="text-sm">استشارة جديدة</span>
-                </Button>
-                <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
-                  <Search className="w-6 h-6" />
-                  <span className="text-sm">تحقيق جديد</span>
-                </Button>
-                <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
-                  <Gavel className="w-6 h-6" />
-                  <span className="text-sm">قضية جديدة</span>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
+                <CardTitle>{t('dashboard.quickActions')}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
+                      <FileText className="w-6 h-6" />
+                      <span className="text-sm">{t('dashboard.newContract')}</span>
+                    </Button>
+                    <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
+                      <Scale className="w-6 h-6" />
+                      <span className="text-sm">{t('dashboard.newAdvice')}</span>
+                    </Button>
+                    <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
+                      <Search className="w-6 h-6" />
+                      <span className="text-sm">{t('dashboard.newInvestigation')}</span>
+                    </Button>
+                    <Button variant="outline" className="h-auto p-4 flex flex-col space-y-2">
+                      <Gavel className="w-6 h-6" />
+                      <span className="text-sm">{t('dashboard.newCase')}</span>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
         </motion.div>
       </div>
     </AppLayout>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -88,7 +88,8 @@ export default {
       },
       boxShadow: {
         'elegant': 'var(--shadow-elegant)',
-        'card': 'var(--shadow-card)'
+        'card': 'var(--shadow-card)',
+        'neon': '0 0 15px rgba(91,192,190,0.5)'
       },
       backgroundImage: {
         'gradient-primary': 'var(--gradient-primary)',


### PR DESCRIPTION
## Summary
- polish card styling with light gradients and neon shadow in dark mode
- support dashboard translations via i18next
- expose new translation strings for dashboard labels and priorities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac16b3aaa8832887e1138b83ca63d7