### PR TITLE
feat: improve dark theme header and sidebar

### DIFF
--- a/frontend/src/components/common/HeaderToggle.jsx
+++ b/frontend/src/components/common/HeaderToggle.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import { useSidebar } from '@/components/ui/sidebar';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useLanguage } from '@/context/LanguageContext';
 
 function HeaderToggle() {
   const { open, toggleSidebar } = useSidebar();
+  const { isRTL } = useLanguage();
+
+  const Icon = isRTL
+    ? open
+      ? ChevronRight
+      : ChevronLeft
+    : open
+    ? ChevronLeft
+    : ChevronRight;
 
   return (
     <button
-      className="text-white mr-2 hover:text-almadar-sidebar-danger dark:text-almadar-mint-light dark:hover:text-almadar-sand transition-colors duration-300 ease-in-out"
+      className="mr-2 text-sidebar-foreground hover:text-sidebar-primary transition-colors duration-300 ease-in-out"
       onClick={toggleSidebar}
       aria-controls="sidebar"
       aria-expanded={open}
@@ -14,17 +25,7 @@ function HeaderToggle() {
       <span className="sr-only">
         {open ? 'Close sidebar' : 'Open sidebar'}
       </span>
-      <svg
-        className="w-6 h-6 fill-current"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        {open ? (
-          <path d="M13.3 5.3l-1.4 1.4L16.2 11H4v2h12.2l-4.3 4.3 1.4 1.4L20 12z" />
-        ) : (
-          <path d="M10.7 18.7l1.4-1.4L7.8 13H20v-2H7.8l4.3-4.3-1.4-1.4L4 12z" />
-        )}
-      </svg>
+      <Icon className="w-6 h-6" />
     </button>
   );
 }

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -47,7 +47,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
           <motion.header
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
-            className="h-16 border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-40"
+            className="h-16 border-b border-border bg-sidebar text-sidebar-foreground sticky top-0 z-40"
           >
             <div className="flex items-center justify-between px-6 h-full">
               <div className={`flex items-center ${isRTL ? 'space-x-reverse' : 'space-x-4'}`}>

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -58,7 +58,7 @@ export default function Sidebar({ onLinkClick }: { onLinkClick?: () => void }) {
             exit={{ x: dir === "rtl" ? 300 : -300, opacity: 0 }}
             transition={{ type: "tween", duration: 0.25 }}
             dir={dir}
-            className={`fixed top-0 ${anchor} z-50 h-screen w-72 bg-card border ${railSide} border-border shadow-lg`}
+            className={`fixed top-0 ${anchor} z-50 h-screen w-72 bg-sidebar text-sidebar-foreground border ${railSide} border-border shadow-lg`}
             style={{
               paddingTop: "env(safe-area-inset-top)",
               paddingBottom: "env(safe-area-inset-bottom)"
@@ -155,7 +155,7 @@ export default function Sidebar({ onLinkClick }: { onLinkClick?: () => void }) {
             exit={{ x: dir === "rtl" ? 96 : -96, opacity: 0 }}
             transition={{ type: "tween", duration: 0.2 }}
             dir={dir}
-            className={`fixed top-0 ${anchor} z-40 h-screen w-16 bg-card border ${railSide} border-border`}
+            className={`fixed top-0 ${anchor} z-40 h-screen w-16 bg-sidebar text-sidebar-foreground border ${railSide} border-border`}
             role="navigation"
             aria-label="Mini sidebar"
             style={{

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
-import { PanelLeft } from "lucide-react"
+import { PanelLeft, PanelRight } from "lucide-react"
+import { useLanguage } from "@/context/LanguageContext"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -262,6 +263,7 @@ const SidebarTrigger = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { isRTL } = useLanguage()
 
   return (
     <Button
@@ -276,7 +278,7 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      <PanelLeft />
+      {isRTL ? <PanelRight /> : <PanelLeft />}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )


### PR DESCRIPTION
## Summary
- unify header and sidebar styling with dark theme colors
- display direction-aware toggle icons for sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac1805aa788328bfa7aff297cec183