### PR TITLE
feat: add bilingual theming and rtl support

### DIFF
--- a/frontend/src/components/common/AddButton.jsx
+++ b/frontend/src/components/common/AddButton.jsx
@@ -1,20 +1,21 @@
 // src/components/common/AddButton.jsx
 import { PlusCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/context/LanguageContext';
 
-export default function AddButton({ label = 'عنصر', onClick }) {
+export default function AddButton({ label = 'item', onClick }) {
+  const { t } = useLanguage();
+
   return (
     <Button
       onClick={onClick}
-      className="w-fit sm:w-auto p-2 rounded-full bg-primary text-primary-foreground hover:bg-primary-hover focus:ring-4 focus:ring-primary-light transition-all duration-300"
+      className="w-fit sm:w-auto p-2 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 shadow-md transition-all duration-300"
       variant="default"
       size="sm"
     >
       <PlusCircle className="w-4 h-4" />
-      <span className="ml-1 sm:hidden">إضافة {label}</span>{' '}
-      {/* Show label on small screens only */}
-      <span className="hidden sm:inline-block">إضافة {label}</span>{' '}
-      {/* Hide label on small screens */}
+      <span className="ml-1 sm:hidden">{t('add')} {t(label)}</span>
+      <span className="hidden sm:inline-block">{t('add')} {t(label)}</span>
     </Button>
   );
 }

--- a/frontend/src/components/common/LanguageSwitcher.jsx
+++ b/frontend/src/components/common/LanguageSwitcher.jsx
@@ -1,0 +1,17 @@
+import { useLanguage } from '@/context/LanguageContext';
+import { Button } from '@/components/ui/button';
+
+export default function LanguageSwitcher() {
+  const { lang, toggleLanguage } = useLanguage();
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={toggleLanguage}
+      className="shadow-sm"
+    >
+      {lang === 'ar' ? 'English' : 'العربية'}
+    </Button>
+  );
+}

--- a/frontend/src/components/dashboard/Header.jsx
+++ b/frontend/src/components/dashboard/Header.jsx
@@ -2,39 +2,33 @@
 import Notifications from '../common/DropdownNotifications';
 import UserMenu from '../common/DropdownProfile';
 import ThemeToggle from '../common/ThemeToggle';
+import LanguageSwitcher from '../common/LanguageSwitcher';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
+import { useLanguage } from '@/context/LanguageContext';
 
-export default function Header({ isOpen,user, onToggleSidebar }) {
-  
+export default function Header({ isOpen, user, onToggleSidebar }) {
+  const { dir } = useLanguage();
+
   return (
- 
-<nav
-  dir="rtl"
-  className={`
-    fixed top-0 left-0 right-0
-    transition-all duration-300
-    ${isOpen ? 'sm:mr-64' : 'sm:mr-16'}
-    py-3 px-6 flex justify-between items-center
-    bg-navy-light dark:bg-black
-    bg-gradient-to-l from-gold via-greenic/80 to-royal/80 
-    dark:bg-gradient-to-l dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
-    text-gray-900 dark:text-white
-    border-b border-gray-200 dark:border-navy-dark
-    shadow-md dark:shadow-[0_01px_#16b8f640]
-    z-20
-  `}
->
-  
-
-
+    <nav
+      dir={dir}
+      className={`
+        fixed top-0 left-0 right-0
+        transition-all duration-300
+        ${isOpen ? 'sm:mr-64' : 'sm:mr-16'}
+        py-3 px-6 flex justify-between items-center
+        bg-sidebar text-sidebar-foreground border-b border-sidebar-border shadow-lg z-20
+      `}
+    >
       <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
-        <Menu className="text-white dark:text-greenic h-5 w-5 hover:text-greenic-light" />
+        <Menu className="h-5 w-5" />
       </Button>
- 
+
       <div className="flex items-center gap-3">
         <Notifications userId={user.id} align="right" />
         <ThemeToggle />
+        <LanguageSwitcher />
         <div className="hidden sm:block w-px h-6 bg-border" />
         <UserMenu align="left" />
       </div>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -95,7 +95,7 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
   return (
     <aside
       dir={dir}
-      className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0  border-r '} top-0 z-20 h-full bg-sidebar text-sidebar-foreground border-l  border-sidebar-border transition-all duration-300 ${
+      className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0  border-r '} top-0 z-20 h-full bg-sidebar text-sidebar-foreground border-l  border-sidebar-border shadow-lg transition-all duration-300 ${
         isLargeScreen
           ? isOpen
             ? 'w-64'

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-shadow ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none shadow-sm hover:shadow-md active:shadow-inner",
   {
     variants: {
       variant: {

--- a/frontend/src/context/LanguageContext.jsx
+++ b/frontend/src/context/LanguageContext.jsx
@@ -13,6 +13,8 @@ const translations = {
     usersList: 'المستخدمين',
     archive: 'الأرشيف',
     fatwa: 'الرأي والفتوى'
+    add: 'إضافة',
+    item: 'عنصر'
   },
   en: {
     home: 'Home',
@@ -25,7 +27,9 @@ const translations = {
     users: 'Users Management',
     usersList: 'Users',
     archive: 'Archive',
-    fatwa: 'Fatwa'
+    fatwa: 'Fatwa',
+    add: 'Add',
+    item: 'Item'
   }
 };
 
@@ -36,6 +40,7 @@ export const LanguageProvider = ({ children }) => {
 
   useEffect(() => {
     document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+    document.documentElement.lang = lang;
   }, [lang]);
 
   const toggleLanguage = () => setLang(prev => (prev === 'ar' ? 'en' : 'ar'));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,4 @@
  
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
- 
 @import './styles/tokens.css';
 
 @tailwind base;
@@ -14,8 +12,6 @@
 
   html {
     font-family: var(--font-body);
-    direction: rtl;
-    lang: ar;
   }
 
   body {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,7 +9,8 @@ import { Suspense } from 'react';
 import ThemeProvider from './utils/ThemeContext';
 import { AuthProvider } from '@/components/auth/AuthContext';
 import { Toaster } from 'sonner';
-import './index.css'; 
+import { LanguageProvider } from './context/LanguageContext';
+import './index.css';
  
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
@@ -27,23 +28,25 @@ registerSW({
 
 root.render(
   <React.StrictMode>
-    <ThemeProvider>
-      <BrowserRouter>
-        <AuthProvider>
-          <SpinnerProvider>
-            <Toaster 
-              position="top-center"
-              toastOptions={{
-                duration: 3000,
-                className: 'touch-target'
-              }}
-            />
-            <Suspense fallback={null}>  
-  <App />
-</Suspense>
-          </SpinnerProvider>
-        </AuthProvider>
-      </BrowserRouter>
-    </ThemeProvider>
+    <LanguageProvider>
+      <ThemeProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <SpinnerProvider>
+              <Toaster
+                position="top-center"
+                toastOptions={{
+                  duration: 3000,
+                  className: 'touch-target'
+                }}
+              />
+              <Suspense fallback={null}>
+                <App />
+              </Suspense>
+            </SpinnerProvider>
+          </AuthProvider>
+        </BrowserRouter>
+      </ThemeProvider>
+    </LanguageProvider>
   </React.StrictMode>
 );

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
   /* Base */
@@ -28,9 +28,13 @@
   --ring: 60 64 198;
 
   /* Sidebar */
-  --sidebar: 17 24 39;
-  --sidebar-foreground: 229 231 235;
-  --sidebar-muted: 100 116 139;
+  --sidebar: 248 250 252;
+  --sidebar-foreground: 30 41 59;
+  --sidebar-muted: 148 163 184;
+  --sidebar-border: 229 231 235;
+  --sidebar-accent: 60 64 198;
+  --sidebar-accent-foreground: 255 255 255;
+  --sidebar-ring: 60 64 198;
 
   /* Gradients */
   --gradient-primary: linear-gradient(135deg, rgb(60 64 198) 0%, rgb(99 102 241) 100%);
@@ -40,8 +44,8 @@
   --shadow-lg: 0 10px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 
   /* Fonts */
-  --font-heading: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial;
-  --font-body: "Cairo", system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  --font-heading: "Tajawal", system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  --font-body: "Tajawal", system-ui, -apple-system, Segoe UI, Roboto, Arial;
 }
 
 .dark {
@@ -51,7 +55,11 @@
   --card-foreground: 243 244 246;
   --popover: 9 13 28;
   --border: 31 41 55;
-  --sidebar: 3 7 18;
+  --sidebar: 31 41 55;
   --sidebar-foreground: 203 213 225;
   --sidebar-muted: 100 116 139;
+  --sidebar-border: 55 65 81;
+  --sidebar-accent: 99 102 241;
+  --sidebar-accent-foreground: 255 255 255;
+  --sidebar-ring: 99 102 241;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -23,6 +23,11 @@ export default {
         border: 'rgb(var(--border) / <alpha-value>)',
         sidebar: 'rgb(var(--sidebar) / <alpha-value>)',
         'sidebar-foreground': 'rgb(var(--sidebar-foreground) / <alpha-value>)',
+        'sidebar-muted': 'rgb(var(--sidebar-muted) / <alpha-value>)',
+        'sidebar-border': 'rgb(var(--sidebar-border) / <alpha-value>)',
+        'sidebar-accent': 'rgb(var(--sidebar-accent) / <alpha-value>)',
+        'sidebar-accent-foreground': 'rgb(var(--sidebar-accent-foreground) / <alpha-value>)',
+        'sidebar-ring': 'rgb(var(--sidebar-ring) / <alpha-value>)',
       },
       boxShadow: {
         lg: 'var(--shadow-lg)',


### PR DESCRIPTION
## Summary
- integrate LanguageProvider and switcher to toggle Arabic/English with RTL layout
- refresh light/dark sidebar theme with Tajawal font and 3D shadows
- beautify buttons and header with consistent styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2aa50c30832884ec9de461f4ffbd