### PR TITLE
feat: refine theme and add language toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ar" dir="rtl" class="dark">
+<html lang="ar" dir="rtl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/src/components/common/LanguageToggle.jsx
+++ b/frontend/src/components/common/LanguageToggle.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useLanguage } from '@/context/LanguageContext';
+import { Button } from '@/components/ui/button';
+
+export default function LanguageToggle() {
+  const { lang, toggleLanguage } = useLanguage();
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleLanguage}
+      aria-label={lang === 'ar' ? 'Switch to English' : 'التبديل إلى العربية'}
+    >
+      {lang === 'ar' ? 'EN' : 'ع'}
+    </Button>
+  );
+}

--- a/frontend/src/components/dashboard/Header.jsx
+++ b/frontend/src/components/dashboard/Header.jsx
@@ -2,29 +2,30 @@
 import Notifications from '../common/DropdownNotifications';
 import UserMenu from '../common/DropdownProfile';
 import ThemeToggle from '../common/ThemeToggle';
+import LanguageToggle from '../common/LanguageToggle';
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
+import { useLanguage } from '@/context/LanguageContext';
 
-export default function Header({ isOpen,user, onToggleSidebar }) {
-  
+export default function Header({ isOpen, user, onToggleSidebar }) {
+  const { dir } = useLanguage();
+
   return (
- 
-<nav
-  dir="rtl"
-  className={`
-    fixed top-0 left-0 right-0
-    transition-all duration-300
-    ${isOpen ? 'lg:mr-64' : 'lg:mr-16'}
-    py-3 px-6 flex justify-between items-center
-    bg-navy-light dark:bg-black
-    bg-gradient-to-l from-gold via-greenic/80 to-royal/80 
-    dark:bg-gradient-to-l dark:from-royal-dark/30 dark:via-royal-dark/40 dark:to-greenic-dark/60
-    text-gray-900 dark:text-white
-    border-b border-gray-200 dark:border-navy-dark
-    shadow-md dark:shadow-[0_01px_#16b8f640]
-    z-20
-  `}
->
+    <nav
+      dir={dir}
+      className={`
+        fixed top-0 left-0 right-0
+        transition-all duration-300
+        ${isOpen ? 'lg:mr-64' : 'lg:mr-16'}
+        py-3 px-6 flex justify-between items-center
+        bg-gradient-to-l from-primary via-secondary to-accent
+        dark:from-accent dark:via-secondary dark:to-primary
+        text-fg
+        border-b border-border
+        shadow-md
+        z-20
+      `}
+    >
   
 
 
@@ -35,6 +36,7 @@ export default function Header({ isOpen,user, onToggleSidebar }) {
       <div className="flex items-center gap-3">
         <Notifications userId={user.id} align="right" />
         <ThemeToggle />
+        <LanguageToggle />
         <div className="hidden sm:block w-px h-6 bg-border" />
         <UserMenu align="left" />
       </div>

--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -96,7 +96,7 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
   return (
     <aside
       dir={dir}
-      style={isDark ? { boxShadow: '0 0 15px rgba(34,211,238,0.35)' } : undefined}
+      style={{ boxShadow: isDark ? '0 0 15px rgba(34,211,238,0.35)' : '0 0 10px rgba(0,0,0,0.1)' }}
       className={`fixed ${dir === 'rtl' ? 'right-0' : 'left-0  border-r '} top-0 z-20 h-full bg-sidebar text-sidebar-fg border-l  border-border transition-all duration-300 ${
         isLargeScreen
           ? isOpen

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:pointer-events-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl text-sm font-medium transition shadow-sm active:shadow-none active:translate-y-[1px] focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:pointer-events-none",
   {
     variants: {
       variant: {

--- a/frontend/src/context/LanguageContext.jsx
+++ b/frontend/src/context/LanguageContext.jsx
@@ -36,6 +36,7 @@ export const LanguageProvider = ({ children }) => {
 
   useEffect(() => {
     document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+    document.documentElement.lang = lang;
   }, [lang]);
 
   const toggleLanguage = () => setLang(prev => (prev === 'ar' ? 'en' : 'ar'));

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -5,6 +5,7 @@
 @layer base {
   :root { color-scheme: light dark; }
   html { -webkit-font-smoothing: antialiased; }
-  body { @apply bg-bg text-fg; }
+  body { @apply bg-bg text-fg font-body; }
+  h1,h2,h3,h4,h5,h6 { @apply font-heading; }
   .card { @apply bg-card border border-border rounded-2xl shadow-md; }
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -2,6 +2,9 @@
    Libya Legal Dashboard — Color Tokens (Light + Dark)
    ----------------------------------------------------------- */
 :root {
+  /* Fonts */
+  --font-heading: 'Cairo', sans-serif;
+  --font-body: 'Cairo', sans-serif;
   /* Base surfaces & text */
   --bg:            #f6f7f9;
   --fg:            #0e1521;
@@ -28,8 +31,8 @@
   --ring:          #10b981;
 
   /* Sidebar */
-  --sidebar-bg:    #ffffff;
-  --sidebar-fg:    #111827;
+  --sidebar-bg:    #ecfdf5;
+  --sidebar-fg:    #064e3b;
   --sidebar-muted: #6b7280;
   --sidebar-active:#0ea5a5;
 
@@ -55,6 +58,7 @@
   --shadow-glow: 0 0 0 2px rgba(18,210,176,0.25), 0 12px 40px rgba(18,210,176,0.25);
 }
 /* DARK THEME */
+
 .dark {
   --bg:            #0b1016;
   --fg:            #e7f5f5;
@@ -78,7 +82,7 @@
   --sidebar-bg:    #0c1218;
   --sidebar-fg:    #e7f5f5;
   --sidebar-muted: #8aa0b3;
-  --sidebar-active:#19c6ae;
+  --sidebar-active:#16e1bf;
 
   --chart-1: #19c6ae;
   --chart-2: #22d3ee;


### PR DESCRIPTION
## Summary
- polish sidebar and header styling for light and dark modes
- add Cairo font and default Arabic/English language toggle
- enhance button appearance with subtle 3D effect

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c30bdc4832893a57dcf45e33b8a