### PR TITLE
feat: add quick create buttons on dashboard

### DIFF
--- a/frontend/src/components/Contracts/ContractsTable.jsx
+++ b/frontend/src/components/Contracts/ContractsTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import TableComponent from "@/components/common/TableComponent";
 import {Button} from "@/components/ui/button";
 import ContractModal from "./ContractModal";
@@ -8,13 +8,17 @@ import { deleteContract } from "../../services/api/contracts";
 import { toast } from "sonner";
 import { motion, AnimatePresence } from "framer-motion"; // ✅ إضافة
 
-export default function ContractsTable({ contracts = [], categories = [], reloadContracts, scope }) {
+export default function ContractsTable({ contracts = [], categories = [], reloadContracts, scope, autoOpen = false }) {
   const [editing, setEditing] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [selectedContract, setSelectedContract] = useState(null);
 
   const filteredContracts = contracts.filter((c) => c.scope === scope);
+
+  useEffect(() => {
+    if (autoOpen) setIsModalOpen(true);
+  }, [autoOpen]);
  
   const openEdit = (row) => {
     setEditing(row);

--- a/frontend/src/components/Litigations/UnifiedLitigationsTable.jsx
+++ b/frontend/src/components/Litigations/UnifiedLitigationsTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState, useContext, useEffect } from "react";
 import { toast } from "sonner";
 import { deleteLitigation } from "@/services/api/litigations";
 import TableComponent from "@/components/common/TableComponent";
@@ -9,7 +9,7 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import LitigationActionsTable from "@/components/Litigations/LitigationActionsTable";
 import { AuthContext } from "@/components/auth/AuthContext";
 
-export default function UnifiedLitigationsTable({ litigations, scope, reloadLitigations }) {
+export default function UnifiedLitigationsTable({ litigations, scope, reloadLitigations, autoOpen = false }) {
   const [expandedId, setExpandedId] = useState(null);
   const [editingItem, setEditingItem] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -36,6 +36,13 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
     setEditingItem(null);
     setIsModalOpen(true);
   };
+
+  useEffect(() => {
+    if (autoOpen) {
+      setEditingItem(null);
+      setIsModalOpen(true);
+    }
+  }, [autoOpen]);
 
   const handleConfirmDelete = async () => {
     if (!deleteTarget) return;

--- a/frontend/src/components/dashboard/DashboardHome.jsx
+++ b/frontend/src/components/dashboard/DashboardHome.jsx
@@ -13,6 +13,7 @@ import RecentTable from './RecentTable';
 import EmptyState from './EmptyState';
 import { useDashboardData } from './useDashboardData';
 import { useLang } from './useLang';
+import QuickActions from './QuickActions';
 
 const LibyaMap = lazy(() => import('./LibyaMap'));
 const SessionsHeatmap = lazy(() => import('./SessionsHeatmap'));
@@ -43,6 +44,7 @@ export default function DashboardHome() {
 
   return (
     <div className="space-y-4">
+      <QuickActions />
       <FiltersBar filters={filters} onChange={setFilters} />
 
       <div className="grid gap-4 grid-cols-4 sm:grid-cols-4 md:grid-cols-8 lg:grid-cols-12">

--- a/frontend/src/components/dashboard/QuickActions.jsx
+++ b/frontend/src/components/dashboard/QuickActions.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import AddButton from '@/components/common/AddButton';
+import { useNavigate } from 'react-router-dom';
+
+export default function QuickActions() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <AddButton label="عقد" onClick={() => navigate('/contracts', { state: { openModal: true } })} />
+      <AddButton label="مشورة" onClick={() => navigate('/legal/legal-advices', { state: { openModal: true } })} />
+      <AddButton label="دعوى" onClick={() => navigate('/legal/litigations', { state: { openModal: true } })} />
+    </div>
+  );
+}

--- a/frontend/src/pages/ContractsPage.jsx
+++ b/frontend/src/pages/ContractsPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, lazy, Suspense } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getContractCategories } from '../services/api/contracts';
 import { LocalIcon, InternationalIcon } from '../assets/icons';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useContracts } from '@/hooks/dataHooks'; // ✅ استخدم الهُوك المُخصص
 const SectionHeader = lazy(() => import('../components/common/SectionHeader'));
 const ContractsTable = lazy(
@@ -13,6 +13,7 @@ export default function Contracts() {
   const [activeTab, setActiveTab] = useState('local');
   const [categories, setCategories] = useState([]);
   const navigate = useNavigate();
+  const location = useLocation();
 
   // ✅ استدعِ البيانات من hook
   const { data, isLoading, refetch } = useContracts();
@@ -101,6 +102,7 @@ export default function Contracts() {
                 reloadContracts={refetch}
                 scope={activeTab}
                 loading={isLoading}
+                autoOpen={location.state?.openModal}
               />
             </Suspense>
           </motion.div>

--- a/frontend/src/pages/LegalAdvicePage.jsx
+++ b/frontend/src/pages/LegalAdvicePage.jsx
@@ -12,12 +12,14 @@ import { motion } from 'framer-motion';
 import { useLegalAdvices } from "@/hooks/dataHooks"; // ✅ من React Query
 import { useQuery } from "@tanstack/react-query"; // لاستدعاء أنواع المشورة
 import API_CONFIG  from "@/config/config";
+import { useLocation } from 'react-router-dom';
 const LegalAdviceModal = lazy(() => import("../components/LegalAdvices/LegalAdviceModal"));
 const LegalAdviceDetails = lazy(() => import("../components/LegalAdvices/LegalAdviceDetails"));
 const GlobalConfirmDeleteModal = lazy(() => import("../components/common/GlobalConfirmDeleteModal"));
 
 export default function LegalAdvicePage() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const location = useLocation();
+  const [isModalOpen, setIsModalOpen] = useState(location.state?.openModal || false);
   const [editingAdvice, setEditingAdvice] = useState(null);
   const [selectedAdvice, setSelectedAdvice] = useState(null);
   const [deleteTarget, setDeleteTarget] = useState(null);

--- a/frontend/src/pages/LitigationsPage.jsx
+++ b/frontend/src/pages/LitigationsPage.jsx
@@ -6,6 +6,7 @@ import SectionHeader from '@/components/common/SectionHeader';
 import { deleteLitigation } from '@/services/api/litigations';
 import { CaseIcon } from '@/assets/icons';
 import { useLitigations } from '@/hooks/dataHooks'; // ✅ hook من React Query
+import { useLocation } from 'react-router-dom';
 const UnifiedLitigationsTable = lazy(
   () => import('@/components/Litigations/UnifiedLitigationsTable'),
 );
@@ -16,6 +17,7 @@ const GlobalConfirmDeleteModal = lazy(
 export default function LitigationsPage() {
   const [activeTab, setActiveTab] = useState('against');
   const [litigationToDelete, setLitigationToDelete] = useState(null);
+  const location = useLocation();
 
   // ✅ استخدام React Query لجلب الدعاوى
   const { data, isLoading, refetch } = useLitigations();
@@ -110,6 +112,7 @@ export default function LitigationsPage() {
                   scope={activeTab}
                   onDelete={setLitigationToDelete}
                   loading={isLoading}
+                  autoOpen={location.state?.openModal}
                 />
               </Suspense>
             </Card>


### PR DESCRIPTION
## Summary
- add QuickActions component with shortcuts to create contracts, legal advices, and litigations
- open creation modals automatically when navigating from dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acbe245468832885aadd382271e543