### PR TITLE
feat: enhance libya map visualization

### DIFF
--- a/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
+++ b/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
@@ -1,9 +1,10 @@
 import React from "react";
+import { scaleLinear } from "d3-scale";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 
 
 const GEO_URL = "/geo/libya.json"; // كفاية كده
-export default function LibyaMapPro({ data = [], onRegionClick, isDark = false }) {
+export default function LibyaMapPro({ data = [], onRegionClick, isDark = false, height = 360 }) {
   // اختياري: تحقّق سريع يمنع الريندر قبل الجاهزية
   const [ready, setReady] = React.useState(false);
   const [err, setErr] = React.useState(null);
@@ -40,25 +41,54 @@ export default function LibyaMapPro({ data = [], onRegionClick, isDark = false }
   }
   if (!ready) return <div className="text-sm opacity-70">Loading map…</div>;
 
+  // Create a lookup for region counts
+  const counts = React.useMemo(() => {
+    const m = new Map();
+    for (const d of data) {
+      if (d?.regionCode) m.set(d.regionCode, Number(d.count) || 0);
+    }
+    return m;
+  }, [data]);
+
+  const max = React.useMemo(() => Math.max(0, ...counts.values()), [counts]);
+  const colorScale = React.useMemo(
+    () =>
+      scaleLinear()
+        .domain([0, max || 1])
+        .range(isDark ? ["#1f2937", "#1d4ed8"] : ["#e5e7eb", "#2563eb"]),
+    [max, isDark]
+  );
+
+  const getId = (g) => g.properties?.id || g.id || g.rsmKey;
+
   // مرِّر URL فقط — اترك التحميل لـ Geographies
   return (
-    <div className="w-full h-[360px]">
+    <div className="w-full" style={{ height }}>
       <ComposableMap projection="geoMercator" projectionConfig={{ scale: 2000, center: [17, 27] }}>
         <Geographies geography={GEO_URL}>
           {({ geographies }) =>
-            geographies.map((g) => (
-              <Geography
-                key={g.rsmKey}
-                geography={g}
-                onClick={() => onRegionClick?.(g.properties?.id || g.id || g.rsmKey)}
-                fill={isDark ? "#1f2937" : "#e5e7eb"}
-                stroke={isDark ? "#334155" : "#9ca3af"}
-                style={{ default:{ outline:"none" }, hover:{ outline:"none", opacity:0.9 }, pressed:{ outline:"none" } }}
-              />
-            ))
+            geographies.map((g) => {
+              const id = getId(g);
+              const count = counts.get(id) || 0;
+              return (
+                <Geography
+                  key={g.rsmKey}
+                  geography={g}
+                  onClick={() => onRegionClick?.(id)}
+                  fill={colorScale(count)}
+                  stroke={isDark ? "#334155" : "#9ca3af"}
+                  style={{
+                    default: { outline: "none" },
+                    hover: { outline: "none", opacity: 0.9 },
+                    pressed: { outline: "none" },
+                  }}
+                />
+              );
+            })
           }
         </Geographies>
       </ComposableMap>
     </div>
   );
 }
+

--- a/frontend/src/components/dashboard/__tests__/LibyaMapPro.test.jsx
+++ b/frontend/src/components/dashboard/__tests__/LibyaMapPro.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('react-simple-maps', () => ({
+  ComposableMap: ({ children }) => <svg>{children}</svg>,
+  Geographies: ({ children }) => (
+    <g>
+      {children({ geographies: [{ rsmKey: 'TRP', id: 'TRP', properties: { id: 'TRP' } }] })}
+    </g>
+  ),
+  Geography: ({ geography, fill }) => <path data-id={geography.properties.id} fill={fill} />,
+}));
+
+import LibyaMapPro from '../Map/LibyaMapPro';
+
+test('renders SVG map and applies fill', () => {
+  const { container } = render(
+    <LibyaMapPro data={[{ regionCode: 'TRP', count: 5 }]} />
+  );
+  expect(container.querySelector('svg')).toBeInTheDocument();
+  const path = container.querySelector('path[data-id="TRP"]');
+  expect(path).toBeInTheDocument();
+  expect(path).toHaveAttribute('fill');
+});


### PR DESCRIPTION
## Summary
- color regions on Libya map using provided data and d3-scale
- allow custom height and dynamic count lookup
- add basic rendering test for LibyaMapPro

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: could not resolve peer dependency for react-simple-maps@1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3e541e08328b2f4592cfe272eb2