### PR TITLE
feat: refine dashboard layout and map theming

### DIFF
--- a/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
+++ b/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ComposableMap, Geographies, Geography, Marker } from 'react-simple-maps';
 import { geoCentroid } from 'd3-geo';
 import { scaleOrdinal } from 'd3-scale';
+import { useThemeProvider } from '@/utils/ThemeContext';
 
 const DEFAULT_GEO_URL = '/geo/LY_regions.geojson';
 const CASES_URL = '/data/cases.libya.json';
@@ -42,11 +43,13 @@ function regionOfEn(en){
 }
 
 export default function LibyaMapPro({
-  mode = 'day',
+  mode = 'auto',
   geographyUrl = DEFAULT_GEO_URL,
   showLabels = true
 }) {
-  const theme = THEMES[mode] || THEMES.day;
+  const { currentTheme } = useThemeProvider();
+  const resolvedMode = mode === 'auto' ? (currentTheme === 'dark' ? 'night' : 'day') : mode;
+  const theme = THEMES[resolvedMode] || THEMES.day;
   const fallbackScale = useMemo(() => scaleOrdinal().range(['#60a5fa','#34d399','#fbbf24','#f472b6','#a78bfa','#f87171']), []);
   const [cases, setCases] = useState({});
   const [tooltip, setTooltip] = useState({ content: '', x: 0, y: 0 });
@@ -62,7 +65,7 @@ export default function LibyaMapPro({
   };
 
   return (
-    <div className="relative w-full h-full bg-transparent">
+    <div className="relative w-full h-full bg-transparent rounded-lg shadow-[0_0_15px_rgba(0,0,0,0.2)] dark:shadow-[0_0_15px_rgba(255,255,255,0.1)]">
       <ComposableMap projection="geoMercator" projectionConfig={{ center: [17.5, 26], scale: 2100 }} style={{ background: 'transparent' }}>
         <Geographies geography={geographyUrl}>
           {({ geographies }) => {

--- a/frontend/src/features/dashboard/pages/Dashboard.jsx
+++ b/frontend/src/features/dashboard/pages/Dashboard.jsx
@@ -158,82 +158,83 @@ export default function Dashboard() {
           />
         </div>
 
-        {/* Professional Libya Map */}
-        <ChartCard
-          title={t('geographicDistribution', lang)}
-          description={t('geoDescription', lang)}
-          delay={0.5}
-          actions={
-            <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
-              <Download className="w-4 h-4" />
-            </button>
-          }
-        >
-          <LibyaMapPro
-            data={data.mapData}
-            onRegionClick={handleRegionClick}
-            height={400}
-          />
-        </ChartCard>
-     
-
-        {/* Charts Row */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Monthly Cases Chart */}
+        {/* Map and charts */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
           <ChartCard
-            title={t('monthlyCases', lang)}
-            description={t('monthlyDescription', lang)}
-            delay={0.6}
+            title={t('geographicDistribution', lang)}
+            description={t('geoDescription', lang)}
+            delay={0.5}
+            className="h-full"
             actions={
               <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
                 <Download className="w-4 h-4" />
               </button>
             }
           >
-            <BarChartBasic
-              data={data.trends}
-              xKey="month"
-              yKey="cases"
-              height={200}
+            <LibyaMapPro
+              data={data.mapData}
+              onRegionClick={handleRegionClick}
+              height={400}
             />
           </ChartCard>
 
-          {/* Case Outcomes */}
-          <ChartCard
-            title={t('caseOutcomes', lang)}
-            description={t('outcomesDescription', lang)}
-            delay={0.7}
-            actions={
-              <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
-                <Filter className="w-4 h-4" />
-              </button>
-            }
-          >
-            <PieChartBasic
-              data={data.distribution}
-              height={200}
-              innerRadius={50}
-            />
-          </ChartCard>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-1 gap-6">
+            {/* Monthly Cases Chart */}
+            <ChartCard
+              title={t('monthlyCases', lang)}
+              description={t('monthlyDescription', lang)}
+              delay={0.6}
+              actions={
+                <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
+                  <Download className="w-4 h-4" />
+                </button>
+              }
+            >
+              <BarChartBasic
+                data={data.trends}
+                xKey="month"
+                yKey="cases"
+                height={200}
+              />
+            </ChartCard>
 
-          {/* Sessions Trend */}
-          <ChartCard
-            title={t('courtSessions', lang)}
-            description={t('sessionsDescription', lang)}
-            delay={0.8}
-            actions={
-              <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
-                <Calendar className="w-4 h-4" />
-              </button>
-            }
-          >
-            <AreaChartBasic
-              data={data.trends}
-              xKey="month"
-              yKey="sessions"
-              height={200}
-            />
-          </ChartCard>
+            {/* Case Outcomes */}
+            <ChartCard
+              title={t('caseOutcomes', lang)}
+              description={t('outcomesDescription', lang)}
+              delay={0.7}
+              actions={
+                <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
+                  <Filter className="w-4 h-4" />
+                </button>
+              }
+            >
+              <PieChartBasic
+                data={data.distribution}
+                height={200}
+                innerRadius={50}
+              />
+            </ChartCard>
+
+            {/* Sessions Trend */}
+            <ChartCard
+              title={t('courtSessions', lang)}
+              description={t('sessionsDescription', lang)}
+              delay={0.8}
+              actions={
+                <button className="p-2 rounded-lg hover:bg-muted/50 transition-colors">
+                  <Calendar className="w-4 h-4" />
+                </button>
+              }
+            >
+              <AreaChartBasic
+                data={data.trends}
+                xKey="month"
+                yKey="sessions"
+                height={200}
+              />
+            </ChartCard>
+          </div>
         </div>
 
         {/* Recent Cases Table */}
@@ -251,5 +252,5 @@ export default function Dashboard() {
         </ChartCard>
       </div>
     </div>
-    );
-  }
+  );
+}


### PR DESCRIPTION
## Summary
- make LibyaMapPro theme-aware and add drop shadow styling
- reorganize dashboard layout with responsive map and chart grid

## Testing
- `npm install`
- `npm test` *(fails: Jest encountered an unexpected token and React testing environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ae83b9941c8328976c86735508b0fb