### PR TITLE
feat: reset Libya map zoom to min level

### DIFF
--- a/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
+++ b/frontend/src/components/dashboard/Map/LibyaMapPro.jsx
@@ -11,6 +11,7 @@ const GEO_URL = "/geo/libya-adm1.geojson";
 
 const LibyaMapPro = ({ dataByRegion = {}, onRegionClick }) => {
   const [hoverInfo, setHoverInfo] = useState(null);
+  const [zoom, setZoom] = useState(1);
 
   // build domain and color scale
   const { colorScale, maxVal } = useMemo(() => {
@@ -46,7 +47,11 @@ const LibyaMapPro = ({ dataByRegion = {}, onRegionClick }) => {
       </div>
 
       <ComposableMap projection="geoMercator">
-        <ZoomableGroup center={[17, 27]} zoom={3.5}>
+        <ZoomableGroup
+          center={[17, 27]}
+          zoom={zoom}
+          onMoveEnd={(position) => setZoom(Math.max(1, position.zoom))}
+        >
           <Geographies geography={GEO_URL}>
             {({ geographies }) =>
               geographies.map((geo) => {

--- a/frontend/src/components/dashboard/__tests__/LibyaMapPro.test.jsx
+++ b/frontend/src/components/dashboard/__tests__/LibyaMapPro.test.jsx
@@ -9,6 +9,7 @@ jest.mock('react-simple-maps', () => ({
     </g>
   ),
   Geography: ({ geography, fill }) => <path data-id={geography.properties.id} fill={fill} />,
+  ZoomableGroup: ({ children }) => <g>{children}</g>,
 }));
 
 import LibyaMapPro from '../Map/LibyaMapPro';


### PR DESCRIPTION
## Summary
- clamp LibyaMapPro zoom to level 1 and store zoom state
- mock `ZoomableGroup` in LibyaMapPro test

## Testing
- `npm test` *(fails: Jest encountered an unexpected token; ReferenceError: fetch is not defined; ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af02ff99bc83289140266110802b6e