### PR TITLE
fix: display legal case chart

### DIFF
--- a/frontend/src/components/dashboard/Charts/LegalCaseDistributionChart.jsx
+++ b/frontend/src/components/dashboard/Charts/LegalCaseDistributionChart.jsx
@@ -1,39 +1,77 @@
-import React, { useState, useEffect } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import { getLegalCaseDistributionData } from "@/features/dashboard/api/dashboard"; // Assuming API file
+import React, { useEffect, useState } from "react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend
+} from "recharts";
+import { getLegalCaseDistributionData } from "@/features/dashboard/api/dashboard";
 
-const LegalCaseDistributionChart = () => {
+export default function LegalCaseDistributionChart({ height = 240 }) {
   const [data, setData] = useState([]);
 
   useEffect(() => {
-    const fetchData = async () => {
+    let mounted = true;
+    (async () => {
       try {
-        const result = await getLegalCaseDistributionData(); // Get data from the API
-        setData(result);
-      } catch (error) {
-        console.error("Error fetching legal case distribution data:", error);
+        const result = await getLegalCaseDistributionData();
+        mounted && setData(result);
+      } catch (e) {
+        console.error("Error fetching legal case distribution data:", e);
       }
+    })();
+    return () => {
+      mounted = false;
     };
-    fetchData();
   }, []);
 
-  if (!data.length) return <div className="text-center p-4">Loading...</div>;
+  if (!data.length) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <span className="text-muted-foreground text-sm">Loading...</span>
+      </div>
+    );
+  }
 
   return (
-    <div className="chart-container bg-card p-6 rounded-xl shadow-md">
-      <h2 className="text-xl font-semibold text-center mb-4">Legal Case Distribution by Category</h2>
-      <ResponsiveContainer width="100%" height={400}>
-        <BarChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="name" />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey="value" fill="#8884d8" />
+    <div style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} barCategoryGap="20%">
+          <CartesianGrid strokeOpacity={0.1} />
+          <XAxis
+            dataKey="name"
+            tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "hsl(var(--card))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: "12px",
+              boxShadow: "var(--glass-shadow)",
+              color: "hsl(var(--foreground))"
+            }}
+          />
+          <Legend
+            wrapperStyle={{
+              fontSize: "12px",
+              color: "hsl(var(--muted-foreground))"
+            }}
+          />
+          <Bar dataKey="value" fill="url(#primaryGradient)" radius={[8, 8, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>
   );
-};
+}
 
-export default LegalCaseDistributionChart; // Ensure this is exported correctly

--- a/frontend/src/features/dashboard/pages/Dashboard.jsx
+++ b/frontend/src/features/dashboard/pages/Dashboard.jsx
@@ -3,8 +3,25 @@ import { motion } from "framer-motion";
 import { Download, Filter, TrendingUp, Scale, Users, Calendar, CheckCircle } from "lucide-react";
 
 // Building blocks
-import { Toolbar, KpiCard, ChartCard, BarChartBasic, AreaChartBasic, PieChartBasic, LibyaMapPro, CompactTable } from "@/components/dashboard";
-import { getKpis, getTrends, getDistribution, getMapData, getRecent,LegalCaseDistributionChart, getMiniSeries } from "../api/dashboard";
+import {
+  Toolbar,
+  KpiCard,
+  ChartCard,
+  BarChartBasic,
+  AreaChartBasic,
+  PieChartBasic,
+  LibyaMapPro,
+  CompactTable,
+  LegalCaseDistributionChart
+} from "@/components/dashboard";
+import {
+  getKpis,
+  getTrends,
+  getDistribution,
+  getMapData,
+  getRecent,
+  getMiniSeries
+} from "../api/dashboard";
 import { useLanguage } from "@/context/LanguageContext";
 
 const fadeIn = (delay = 0) => ({


### PR DESCRIPTION
## Summary
- fix LegalCaseDistributionChart import in dashboard
- restyle LegalCaseDistributionChart to use theme variables

## Testing
- `npm test` *(fails: Geo check failed: ReferenceError: fetch is not defined; Jest encountered unexpected token; ReferenceError: ResizeObserver is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b18e7b7530832898575df51f19110f