### PR TITLE
feat: route table rows to standalone detail pages

### DIFF
--- a/frontend/src/components/Contracts/ContractsTable.jsx
+++ b/frontend/src/components/Contracts/ContractsTable.jsx
@@ -1,18 +1,17 @@
 import React, { useState, useEffect } from "react";
 import TableComponent from "@/components/common/TableComponent";
-import {Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import ContractModal from "./ContractModal";
 import GlobalConfirmDeleteModal from "../common/GlobalConfirmDeleteModal";
-import ContractDetails from "./ContractDetails";
 import { deleteContract } from "../../services/api/contracts";
 import { toast } from "sonner";
-import { motion, AnimatePresence } from "framer-motion"; // ✅ إضافة
+import { useNavigate } from "react-router-dom";
 
 export default function ContractsTable({ contracts = [], categories = [], reloadContracts, scope, autoOpen = false }) {
   const [editing, setEditing] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
-  const [selectedContract, setSelectedContract] = useState(null);
+  const navigate = useNavigate();
 
   const filteredContracts = contracts.filter((c) => c.scope === scope);
 
@@ -82,36 +81,7 @@ export default function ContractsTable({ contracts = [], categories = [], reload
       </Button>
     ),
   }}
-  onRowClick={(row) =>
-    setSelectedContract((prev) => (prev?.id === row.id ? null : row))
-  }
-  expandedRowRenderer={(row) =>
-    selectedContract?.id === row.id && (
-      <tr>
-        <td colSpan={6} className="bg-muted/40">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={row.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.4 }}
-              className="p-6"
-            >
-              <div className="flex justify-center">
-                <div className="w-full max-w-3xl">
-                  <ContractDetails
-                    selected={row}
-                    onClose={() => setSelectedContract(null)}
-                  />
-                </div>
-              </div>
-            </motion.div>
-          </AnimatePresence>
-        </td>
-      </tr>
-    )
-  }
+  onRowClick={(row) => navigate(`/contracts/${row.id}`, { state: row })}
 /> {/* ✅ تم إغلاق TableComponent هنا */}
 
       {/* نافذة التعديل أو الإضافة */}

--- a/frontend/src/components/Litigations/UnifiedLitigationsTable.jsx
+++ b/frontend/src/components/Litigations/UnifiedLitigationsTable.jsx
@@ -4,16 +4,15 @@ import { deleteLitigation } from "@/services/api/litigations";
 import TableComponent from "@/components/common/TableComponent";
 import LitigationModal from "@/components/Litigations/LitigationModal";
 import GlobalConfirmDeleteModal from "@/components/common/GlobalConfirmDeleteModal";
-import {Button} from "@/components/ui/button";
-import { ChevronDown, ChevronRight } from "lucide-react";
-import LitigationActionsTable from "@/components/Litigations/LitigationActionsTable";
+import { Button } from "@/components/ui/button";
 import { AuthContext } from "@/context/AuthContext";
+import { useNavigate } from "react-router-dom";
 
 export default function UnifiedLitigationsTable({ litigations, scope, reloadLitigations, autoOpen = false }) {
-  const [expandedId, setExpandedId] = useState(null);
   const [editingItem, setEditingItem] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const navigate = useNavigate();
 
   const { hasPermission } = useContext(AuthContext);
   const moduleName = `litigation-${scope}`;
@@ -21,10 +20,6 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
     const parts = moduleName.split("-");
     const attempts = [moduleName, parts.slice(0, 2).join("-"), parts[0]];
     return attempts.some((mod) => hasPermission(`${action} ${mod}`));
-  };
-
-  const toggleRowExpand = (id) => {
-    setExpandedId((prev) => (prev === id ? null : id));
   };
 
   const handleEdit = (row) => {
@@ -58,7 +53,6 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
   };
 
   const headers = [
-    { key: "expand", text: "" },
     { key: "case_number", text: "رقم الدعوى" },
     { key: "court", text: "المحكمة" },
     { key: "opponent", text: "الخصم" },
@@ -67,18 +61,6 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
   ];
 
   const customRenderers = {
-    expand: (row) => (
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          toggleRowExpand(row.id);
-        }}
-        className="text-gray-700 dark:text-white"
-        title="عرض الإجراءات"
-      >
-        {expandedId === row.id ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-      </button>
-    ),
     status: (row) => {
       const statusMap = {
         open: "مفتوحة",
@@ -100,19 +82,6 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
     },
   };
 
-  const expandedRowRenderer = (row) =>
-    expandedId === row.id ? (
-      <tr key={`expanded-${row.id}`}>
-        <td colSpan={headers.length + 2} className="bg-gray-50 dark:bg-navy-darker p-4">
-          <LitigationActionsTable
-            litigationId={row.id}
-            scope={scope}
-            reloadLitigations={reloadLitigations}
-          />
-        </td>
-      </tr>
-    ) : null;
-
   if (!can("view")) {
     return (
       <div className="p-6 bg-yellow-100 dark:bg-gray-800 text-center rounded-xl text-red-600 dark:text-yellow-300 font-semibold">
@@ -130,7 +99,7 @@ export default function UnifiedLitigationsTable({ litigations, scope, reloadLiti
         customRenderers={customRenderers}
         onEdit={can("edit") ? handleEdit : null}
         onDelete={can("delete") ? (row) => setDeleteTarget(row) : null}
-        expandedRowRenderer={expandedRowRenderer}
+        onRowClick={(row) => navigate(`/legal/litigations/${row.id}`, { state: row })}
         renderAddButton={can("create") ? { render: () => (
                     <Button
                       onClick={handleAdd}

--- a/frontend/src/components/common/TableComponent.jsx
+++ b/frontend/src/components/common/TableComponent.jsx
@@ -14,7 +14,6 @@ export default function TableComponent({
   onView,
   renderAddButton,
   onRowClick,
-  expandedRowRenderer,
 }) {
   const { hasPermission } = useContext(AuthContext);
   const [searchQuery, setSearchQuery] = useState('');
@@ -212,11 +211,11 @@ export default function TableComponent({
           </thead>
           <tbody className="divide-y divide-border">
             {paginatedData.map((row) => (
-              <React.Fragment key={row.id}>
-                <tr
-                  className="transition cursor-pointer hover:bg-secondary/30"
-                  onClick={() => onRowClick?.(row)}
-                >
+              <tr
+                key={row.id}
+                className="transition cursor-pointer hover:bg-secondary/30"
+                onClick={() => onRowClick?.(row)}
+              >
                   <td className="p-2 text-center">
                     <input
                       type="checkbox"
@@ -273,9 +272,7 @@ export default function TableComponent({
                       </button>
                     )}
                   </td>
-                </tr>
-                {expandedRowRenderer?.(row)}
-              </React.Fragment>
+              </tr>
             ))}
           </tbody>
         </table>

--- a/frontend/src/components/layout/AuthRoutes.jsx
+++ b/frontend/src/components/layout/AuthRoutes.jsx
@@ -10,9 +10,13 @@ import ProfilePage from '../../pages/ProfilePage.jsx';
 const Home = lazy(() => import('../../pages/Dashboard.jsx'));
 const ProfileUser = lazy(() => import('../Settings/ProfileUser'));
 const Contracts = lazy(() => import('../../pages/ContractsPage.jsx'));
+const ContractDetailsPage = lazy(() => import('../../pages/ContractDetailsPage.jsx'));
 const Investigations = lazy(() => import('../../pages/InvestigationsPage.jsx'));
+const InvestigationDetailsPage = lazy(() => import('../../pages/InvestigationDetailsPage.jsx'));
 const LegalAdvices = lazy(() => import('../../pages/LegalAdvicePage.jsx'));
+const LegalAdviceDetailsPage = lazy(() => import('../../pages/LegalAdviceDetailsPage.jsx'));
 const Litigations = lazy(() => import('../../pages/LitigationsPage.jsx'));
+const LitigationDetailsPage = lazy(() => import('../../pages/LitigationDetailsPage.jsx'));
 const UserManagementPage = lazy(() => import('../../pages/UserManagementPage.jsx'));
 const ArchivePage = lazy(() => import('../../pages/ArchivePage.jsx'));
 const ManagementSettings = lazy(() => import('../../pages/ManagementSettings.jsx'));
@@ -40,11 +44,15 @@ const AuthRoutes = () => {
           <Route path="/profile/:userId" element={<ProfileUser />} />
           <Route path="/archive" element={<ArchivePage />} />
           <Route path="/contracts" element={<ProtectedRoute permission="view contracts"><Contracts /></ProtectedRoute>} />
+          <Route path="/contracts/:id" element={<ProtectedRoute permission="view contracts"><ContractDetailsPage /></ProtectedRoute>} />
           <Route path="/profile" element={<ProtectedRoute permission="view profile"><ProfilePage /></ProtectedRoute>} />
           <Route path="/users" element={<ProtectedRoute permission="view users"><UserManagementPage /></ProtectedRoute>} />
           <Route path="/legal/investigations" element={<ProtectedRoute permission="view investigations"><Investigations /></ProtectedRoute>} />
+          <Route path="/legal/investigations/:id" element={<ProtectedRoute permission="view investigations"><InvestigationDetailsPage /></ProtectedRoute>} />
           <Route path="/legal/legal-advices" element={<ProtectedRoute permission="view legaladvices"><LegalAdvices /></ProtectedRoute>} />
+          <Route path="/legal/legal-advices/:id" element={<ProtectedRoute permission="view legaladvices"><LegalAdviceDetailsPage /></ProtectedRoute>} />
           <Route path="/legal/litigations" element={<ProtectedRoute permission="view litigations"><Litigations /></ProtectedRoute>} />
+          <Route path="/legal/litigations/:id" element={<ProtectedRoute permission="view litigations"><LitigationDetailsPage /></ProtectedRoute>} />
           <Route path="/managment-lists" element={<ProtectedRoute permission="view managment-lists"><ManagementSettings /></ProtectedRoute>} />
           <Route path="/reports-page" element={<ReportsPage />} />
           <Route path="/forbidden" element={<Forbidden />} />

--- a/frontend/src/pages/ContractDetailsPage.jsx
+++ b/frontend/src/pages/ContractDetailsPage.jsx
@@ -1,0 +1,30 @@
+import { lazy, Suspense } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { useContracts } from "@/hooks/dataHooks";
+
+const ContractDetails = lazy(() => import("../components/Contracts/ContractDetails"));
+
+export default function ContractDetailsPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const location = useLocation();
+  const { data } = useContracts();
+  const contracts = data?.data?.data || [];
+  const contract = location.state || contracts.find((c) => c.id === Number(id));
+
+  if (!contract) {
+    return <div className="p-4">لا توجد بيانات</div>;
+  }
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
+      <Button onClick={() => navigate(-1)} className="mb-4">
+        رجوع
+      </Button>
+      <Suspense fallback={<div>تحميل التفاصيل...</div>}>
+        <ContractDetails selected={contract} onClose={() => navigate(-1)} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/pages/InvestigationDetailsPage.jsx
+++ b/frontend/src/pages/InvestigationDetailsPage.jsx
@@ -1,0 +1,30 @@
+import { lazy, Suspense } from "react";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { useInvestigations } from "@/hooks/dataHooks";
+
+const InvestigationActionsTable = lazy(() => import("@/components/Investigations/InvestigationActionsTable"));
+
+export default function InvestigationDetailsPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const location = useLocation();
+  const { data, refetch } = useInvestigations();
+  const investigations = data?.data?.data || [];
+  const investigation = location.state || investigations.find((i) => i.id === Number(id));
+
+  if (!investigation) {
+    return <div className="p-4">لا توجد بيانات</div>;
+  }
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
+      <Button onClick={() => navigate(-1)} className="mb-4">
+        رجوع
+      </Button>
+      <Suspense fallback={<div>تحميل البيانات...</div>}>
+        <InvestigationActionsTable investigationId={investigation.id} reloadInvestigations={refetch} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/pages/InvestigationsPage.jsx
+++ b/frontend/src/pages/InvestigationsPage.jsx
@@ -1,26 +1,25 @@
 import { useState, lazy, Suspense } from "react";
-  import { toast } from "sonner";
-  import {
-    createInvestigation,
-    updateInvestigation,
-    deleteInvestigation,
-  } from "@/services/api/investigations";
-  import { ChevronDown, ChevronRight } from "lucide-react";
-  import { motion } from 'framer-motion';
-  import TableComponent from "@/components/common/TableComponent";
-  import SectionHeader from "@/components/common/SectionHeader"; 
-  import { Button } from "@/components/ui/button"; 
-  import { InvestigationSection } from "@/assets/icons"; 
-  import { useInvestigations } from "../hooks/dataHooks";
+import { toast } from "sonner";
+import {
+  createInvestigation,
+  updateInvestigation,
+  deleteInvestigation,
+} from "@/services/api/investigations";
+import { motion } from 'framer-motion';
+import TableComponent from "@/components/common/TableComponent";
+import SectionHeader from "@/components/common/SectionHeader";
+import { Button } from "@/components/ui/button";
+import { InvestigationSection } from "@/assets/icons";
+import { useInvestigations } from "../hooks/dataHooks";
+import { useNavigate } from 'react-router-dom';
 const InvestigationModal = lazy(() => import("@/components/Investigations/InvestigationModal"));
-const InvestigationActionsTable = lazy(() => import("@/components/Investigations/InvestigationActionsTable"));
 const GlobalConfirmDeleteModal = lazy(() => import("@/components/common/GlobalConfirmDeleteModal"));
 
   export default function InvestigationsPage() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingItem, setEditingItem] = useState(null);
-    const [expandedId, setExpandedId] = useState(null);
     const [toDelete, setToDelete] = useState(null);
+    const navigate = useNavigate();
 
     const moduleName = "investigations";
     const { data, isLoading, refetch } = useInvestigations();
@@ -61,12 +60,7 @@ const GlobalConfirmDeleteModal = lazy(() => import("@/components/common/GlobalCo
       }
     };
 
-    const toggleRowExpand = (id) => {
-      setExpandedId((prev) => (prev === id ? null : id));
-    };
-
     const headers = [
-      { key: "expand", text: "" },
       { key: "employee_name", text: "الموظف" },
       { key: "source", text: "الجهة المحيلة" },
       { key: "subject", text: "الموضوع" },
@@ -75,11 +69,6 @@ const GlobalConfirmDeleteModal = lazy(() => import("@/components/common/GlobalCo
     ];
 
     const customRenderers = {
-      expand: (row) => (
-        <button onClick={(e) => { e.stopPropagation(); toggleRowExpand(row.id); }}>
-          {expandedId === row.id ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-        </button>
-      ),
       status: (row) => (
         <span className="font-semibold text-red-600 dark:text-yellow-300">
           {row.status}
@@ -109,7 +98,7 @@ const GlobalConfirmDeleteModal = lazy(() => import("@/components/common/GlobalCo
           <TableComponent
             title="قسم التحقيقات القانونية"
             data={investigations}
-            headers={headers} 
+            headers={headers}
             customRenderers={customRenderers}
             moduleName={moduleName}
             renderAddButton={{
@@ -124,21 +113,7 @@ const GlobalConfirmDeleteModal = lazy(() => import("@/components/common/GlobalCo
             }}
             onEdit={handleEdit}
             onDelete={(row) => setToDelete(row)}
-            expandedRowRenderer={(row) =>
-              expandedId === row.id && (
-                <tr>
-                  <td colSpan={headers.length + 2} className="p-4 bg-gray-50 dark:bg-gray-800">
-                    <Suspense fallback={<div>تحميل البيانات...</div>}>
-                    <InvestigationActionsTable
-                      investigationId={row.id}
-                      actions={row.actions || []}
-                      reloadInvestigations={refetch}
-                    />
-                  </Suspense>
-                  </td>
-                </tr>
-              )
-            }
+            onRowClick={(row) => navigate(`/legal/investigations/${row.id}`, { state: row })}
           />
         </motion.div>
 

--- a/frontend/src/pages/LegalAdviceDetailsPage.jsx
+++ b/frontend/src/pages/LegalAdviceDetailsPage.jsx
@@ -1,0 +1,29 @@
+import { lazy, Suspense } from "react";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { useLegalAdvices } from "@/hooks/dataHooks";
+
+const LegalAdviceDetails = lazy(() => import("../components/LegalAdvices/LegalAdviceDetails"));
+
+export default function LegalAdviceDetailsPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const location = useLocation();
+  const { data } = useLegalAdvices();
+  const advice = location.state || data?.data?.find((a) => a.id === Number(id));
+
+  if (!advice) {
+    return <div className="p-4">لا توجد بيانات</div>;
+  }
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
+      <Button onClick={() => navigate(-1)} className="mb-4">
+        رجوع
+      </Button>
+      <Suspense fallback={<div>تحميل التفاصيل...</div>}>
+        <LegalAdviceDetails selected={advice} onClose={() => navigate(-1)} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/pages/LegalAdvicePage.jsx
+++ b/frontend/src/pages/LegalAdvicePage.jsx
@@ -12,17 +12,16 @@ import { motion } from 'framer-motion';
 import { useLegalAdvices } from "@/hooks/dataHooks"; // ✅ من React Query
 import { useQuery } from "@tanstack/react-query"; // لاستدعاء أنواع المشورة
 import API_CONFIG  from "@/config/config";
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 const LegalAdviceModal = lazy(() => import("../components/LegalAdvices/LegalAdviceModal"));
-const LegalAdviceDetails = lazy(() => import("../components/LegalAdvices/LegalAdviceDetails"));
 const GlobalConfirmDeleteModal = lazy(() => import("../components/common/GlobalConfirmDeleteModal"));
 
 export default function LegalAdvicePage() {
   const location = useLocation();
   const [isModalOpen, setIsModalOpen] = useState(location.state?.openModal || false);
   const [editingAdvice, setEditingAdvice] = useState(null);
-  const [selectedAdvice, setSelectedAdvice] = useState(null);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const navigate = useNavigate();
 
   const { hasPermission } = useContext(AuthContext);
   const moduleName = "legaladvices";
@@ -113,19 +112,7 @@ export default function LegalAdvicePage() {
                 <span className="text-gray-400">لا يوجد</span>
               )
           }}
-          onRowClick={(row) =>
-            setSelectedAdvice((prev) => (prev?.id === row.id ? null : row))
-          }
-          expandedRowRenderer={(row) =>
-            selectedAdvice?.id === row.id && (
-              <tr>
-                <td colSpan={7} className="bg-muted/40 px-4 pb-6">
-                       <Suspense fallback={<div>تحميل التفاصيل...</div>}>
-                    <LegalAdviceDetails selected={selectedAdvice} onClose={() => setSelectedAdvice(null)} />
-                  </Suspense>                </td>
-              </tr>
-            )
-          }
+          onRowClick={(row) => navigate(`/legal/legal-advices/${row.id}`, { state: row })}
         />
       </motion.div>
 

--- a/frontend/src/pages/LitigationDetailsPage.jsx
+++ b/frontend/src/pages/LitigationDetailsPage.jsx
@@ -1,0 +1,30 @@
+import { lazy, Suspense } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { Button } from "../components/ui/button";
+import { useLitigations } from "@/hooks/dataHooks";
+
+const LitigationActionsTable = lazy(() => import("@/components/Litigations/LitigationActionsTable"));
+
+export default function LitigationDetailsPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const location = useLocation();
+  const { data, refetch } = useLitigations();
+  const litigations = data?.data?.data || [];
+  const litigation = location.state || litigations.find((l) => l.id === Number(id));
+
+  if (!litigation) {
+    return <div className="p-4">لا توجد بيانات</div>;
+  }
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
+      <Button onClick={() => navigate(-1)} className="mb-4">
+        رجوع
+      </Button>
+      <Suspense fallback={<div>تحميل البيانات...</div>}>
+        <LitigationActionsTable litigationId={litigation.id} scope={litigation.scope} reloadLitigations={refetch} />
+      </Suspense>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- drop expandable row support in TableComponent
- navigate table rows to dedicated detail pages
- add routes and pages for contract, investigation, advice and litigation details

## Testing
- `npm test` *(fails: Geo check failed: ReferenceError: fetch is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b52630e428832885bb85545093401e