### PR TITLE
Fix missing dashboard API exports

### DIFF
--- a/frontend/src/services/api/dashboard.js
+++ b/frontend/src/services/api/dashboard.js
@@ -1,31 +1,10 @@
-// جميع الدوال ترجع Promise لح模拟 async
-export const getKpis = async (filters) => ({
-  totalCases: 324,
-  won: 188,
-  lost: 92,
-  successRate: 67.9,
-  contractsVolume: 12_500_000,
-});
+import api from './axiosConfig';
 
-export const getTrends = async (filters) => [
-  // months: 'YYYY-MM'
-  { month: "2025-01", cases: 120, sessions: 45, actions: 60 },
-  // … 11 شهرًا
-];
+// --- Dashboard API calls ---
 
-export const getDistribution = async (filters) => [
-  { label: "Open", value: 30 },
-  { label: "InProgress", value: 55 },
-  { label: "Closed", value: 35 },
-];
+// جلب إحصائيات اللوحة (contracts, litigations, investigations, legal_advices)
+export const getDashboardCounts = () => api.get('/api/dashboard/statistics');
 
-export const getMapData = async (filters) => [
-  // regionCode يطابق حقول GeoJSON التي تعتمدها
-  { regionCode: "TRP", name: "طرابلس", count: 42 },
-  // …
-];
+// جلب أحدث البيانات المضافة والمحدثة
+export const getAllRecentData = () => api.get('/api/dashboard/get-recent-data');
 
-export const getRecent = async ({ limit = 10, filters }) => [
-  { id: "1", title: "قضية 123", type: "Litigation", region: "TRP", status: "Open", date: "2025-08-01" },
-  // …
-];


### PR DESCRIPTION
## Summary
- implement dashboard service functions for statistics and recent data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: The symbol "navigate" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b561a0a1948328801a8cef54c75c44