### PR TITLE
Remove edit/delete actions from detail pages

### DIFF
--- a/frontend/src/pages/ContractDetailsPage.jsx
+++ b/frontend/src/pages/ContractDetailsPage.jsx
@@ -1,96 +1,37 @@
-import { lazy, Suspense, useState, useContext } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { Button } from "../components/ui/button";
-import { useContracts, useContractCategories } from "@/hooks/dataHooks";
-import { deleteContract } from "@/services/api/contracts";
-import { toast } from "sonner";
-import { AuthContext } from "@/context/AuthContext";
+import { useContracts } from "@/hooks/dataHooks";
 
 const ContractDetails = lazy(() => import("../components/Contracts/ContractDetails"));
-const ContractModal = lazy(() => import("../components/Contracts/ContractModal"));
-const GlobalConfirmDeleteModal = lazy(() => import("../components/common/GlobalConfirmDeleteModal"));
 
 export default function ContractDetailsPage() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
-  const { hasPermission } = useContext(AuthContext);
 
-  const { data, refetch } = useContracts();
-  const { data: categoriesData } = useContractCategories();
+  const { data } = useContracts();
 
   const contracts = data?.data?.data || [];
   const initialContract = location.state || contracts.find((c) => c.id === Number(id));
 
-  const [current, setCurrent] = useState(initialContract || null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [current] = useState(initialContract || null);
 
   if (!current) {
     return <div className="p-4">لا توجد بيانات</div>;
   }
 
-  const reloadContract = async () => {
-    const res = await refetch();
-    const list = res?.data?.data || [];
-    const updated = list.find((c) => c.id === current.id);
-    if (updated) setCurrent(updated);
-  };
-
-  const handleDelete = async () => {
-    try {
-      await deleteContract(current.id);
-      toast.success("تم حذف العقد بنجاح");
-      await refetch();
-      navigate(-1);
-    } catch (e) {
-      toast.error("فشل حذف العقد");
-    } finally {
-      setConfirmDelete(false);
-    }
-  };
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
       <div className="mb-4 flex gap-2">
         <Button onClick={() => navigate(-1)}>رجوع</Button>
-        {hasPermission("edit contracts") && (
-          <Button onClick={() => setIsModalOpen(true)}>تعديل</Button>
-        )}
-        {hasPermission("delete contracts") && (
-          <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            حذف
-          </Button>
-        )}
       </div>
 
       <Suspense fallback={<div>تحميل التفاصيل...</div>}>
         <ContractDetails selected={current} onClose={() => navigate(-1)} />
       </Suspense>
 
-      <Suspense fallback={null}>
-        {isModalOpen && (
-          <ContractModal
-            isOpen={isModalOpen}
-            onClose={() => setIsModalOpen(false)}
-            initialData={current}
-            categories={categoriesData || []}
-            reloadContracts={reloadContract}
-          />
-        )}
-
-        {confirmDelete && (
-          <GlobalConfirmDeleteModal
-            isOpen={confirmDelete}
-            onClose={() => setConfirmDelete(false)}
-            onConfirm={handleDelete}
-            title="تأكيد حذف العقد"
-            description={`هل تريد حذف العقد رقم ${current.number ?? ""}؟ لا يمكن التراجع عن هذه العملية.`}
-            confirmText="حذف"
-            cancelText="إلغاء"
-          />
-        )}
-      </Suspense>
     </div>
   );
 }

--- a/frontend/src/pages/InvestigationDetailsPage.jsx
+++ b/frontend/src/pages/InvestigationDetailsPage.jsx
@@ -1,82 +1,32 @@
-import { lazy, Suspense, useState, useContext } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { useInvestigations } from "@/hooks/dataHooks";
-import { updateInvestigation, deleteInvestigation } from "@/services/api/investigations";
-import { toast } from "sonner";
-import { AuthContext } from "@/context/AuthContext";
 
 const InvestigationActionsTable = lazy(() =>
   import("@/components/Investigations/InvestigationActionsTable")
-);
-const InvestigationModal = lazy(() =>
-  import("@/components/Investigations/InvestigationModal")
-);
-const GlobalConfirmDeleteModal = lazy(() =>
-  import("@/components/common/GlobalConfirmDeleteModal")
 );
 
 export default function InvestigationDetailsPage() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
-  const { hasPermission } = useContext(AuthContext);
 
   const { data, refetch } = useInvestigations();
   const investigations = data?.data?.data || [];
   const initial = location.state || investigations.find((i) => i.id === Number(id));
 
-  const [current, setCurrent] = useState(initial || null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [current] = useState(initial || null);
 
   if (!current) {
     return <div className="p-4">لا توجد بيانات</div>;
   }
 
-  const reloadInvestigation = async () => {
-    const res = await refetch();
-    const list = res?.data?.data || [];
-    const updated = list.find((i) => i.id === current.id);
-    if (updated) setCurrent(updated);
-  };
-
-  const handleSave = async (form) => {
-    try {
-      await updateInvestigation(current.id, form);
-      toast.success("تم التعديل بنجاح");
-      setIsModalOpen(false);
-      await reloadInvestigation();
-    } catch {
-      toast.error("فشل في التعديل");
-    }
-  };
-
-  const handleDelete = async () => {
-    try {
-      await deleteInvestigation(current.id);
-      toast.success("تم حذف التحقيق بنجاح");
-      await refetch();
-      navigate(-1);
-    } catch {
-      toast.error("فشل حذف التحقيق");
-    } finally {
-      setConfirmDelete(false);
-    }
-  };
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
       <div className="mb-4 flex gap-2">
         <Button onClick={() => navigate(-1)}>رجوع</Button>
-        {hasPermission?.("edit investigations") && (
-          <Button onClick={() => setIsModalOpen(true)}>تعديل</Button>
-        )}
-        {hasPermission?.("delete investigations") && (
-          <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            حذف
-          </Button>
-        )}
       </div>
 
       <div className="mb-6 p-4 bg-card text-fg rounded-xl shadow">
@@ -111,28 +61,6 @@ export default function InvestigationDetailsPage() {
         />
       </Suspense>
 
-      <Suspense fallback={null}>
-        {isModalOpen && (
-          <InvestigationModal
-            isOpen={isModalOpen}
-            onClose={() => setIsModalOpen(false)}
-            initialData={current}
-            onSubmit={handleSave}
-          />
-        )}
-
-        {confirmDelete && (
-          <GlobalConfirmDeleteModal
-            isOpen={confirmDelete}
-            onClose={() => setConfirmDelete(false)}
-            onConfirm={handleDelete}
-            title="تأكيد حذف التحقيق"
-            description={`هل تريد حذف تحقيق الموظف ${current.employee_name ?? ""}؟ لا يمكن التراجع عن هذه العملية.`}
-            confirmText="حذف"
-            cancelText="إلغاء"
-          />
-        )}
-      </Suspense>
     </div>
   );
 }

--- a/frontend/src/pages/LegalAdviceDetailsPage.jsx
+++ b/frontend/src/pages/LegalAdviceDetailsPage.jsx
@@ -1,85 +1,34 @@
-import { lazy, Suspense, useState, useContext } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { Button } from "../components/ui/button";
-import { useLegalAdvices, useAdviceTypes } from "@/hooks/dataHooks";
-import { deleteLegalAdvice } from "@/services/api/legalAdvices";
-import { toast } from "sonner";
-import { AuthContext } from "@/context/AuthContext";
+import { useLegalAdvices } from "@/hooks/dataHooks";
 
 const LegalAdviceDetails = lazy(() =>
   import("../components/LegalAdvices/LegalAdviceDetails")
-);
-const LegalAdviceModal = lazy(() =>
-  import("../components/LegalAdvices/LegalAdviceModal")
-);
-const GlobalConfirmDeleteModal = lazy(() =>
-  import("../components/common/GlobalConfirmDeleteModal")
 );
 
 export default function LegalAdviceDetailsPage() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
-  const { hasPermission } = useContext(AuthContext);
-
   // البيانات الأساسية
-  const { data, refetch } = useLegalAdvices();
-  const { data: typesData } = useAdviceTypes();
+  const { data } = useLegalAdvices();
   const advices = data?.data || [];
 
   // تحديد المشورة الحالية
   const initialAdvice = location.state || advices.find((a) => a.id === Number(id));
-  const [current, setCurrent] = useState(initialAdvice);
-
-  // مودالات
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [current] = useState(initialAdvice);
 
   if (!current) {
     return <div className="p-4">لا توجد بيانات</div>;
   }
 
-  // إعادة تحميل بيانات المشورة بعد التعديل
-  const reloadAdvice = async () => {
-    try {
-      const res = await refetch();
-      const list = res?.data || [];
-      const updated = list.find((a) => a.id === current.id);
-      if (updated) setCurrent(updated);
-    } catch {
-      toast.error("فشل تحديث البيانات");
-    }
-  };
-
-  // حذف المشورة
-  const handleDelete = async () => {
-    try {
-      await deleteLegalAdvice(current.id);
-      toast.success("تم حذف المشورة بنجاح");
-      await refetch();
-      navigate(-1);
-    } catch {
-      toast.error("فشل حذف المشورة");
-    } finally {
-      setConfirmDelete(false);
-    }
-  };
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
       {/* أزرار التحكم */}
       <div className="mb-4 flex gap-2">
         <Button onClick={() => navigate(-1)}>رجوع</Button>
-
-        {hasPermission("edit legaladvices") && (
-          <Button onClick={() => setIsModalOpen(true)}>تعديل</Button>
-        )}
-
-        {hasPermission("delete legaladvices") && (
-          <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            حذف
-          </Button>
-        )}
       </div>
 
       {/* تفاصيل المشورة */}
@@ -87,30 +36,6 @@ export default function LegalAdviceDetailsPage() {
         <LegalAdviceDetails selected={current} onClose={() => navigate(-1)} />
       </Suspense>
 
-      {/* مودال تعديل وحذف */}
-      <Suspense fallback={null}>
-        {isModalOpen && (
-          <LegalAdviceModal
-            isOpen={isModalOpen}
-            onClose={() => setIsModalOpen(false)}
-            adviceTypes={typesData || []}
-            initialData={current}
-            reload={reloadAdvice}
-          />
-        )}
-
-        {confirmDelete && (
-          <GlobalConfirmDeleteModal
-            isOpen={confirmDelete}
-            onClose={() => setConfirmDelete(false)}
-            onConfirm={handleDelete}
-            title="تأكيد حذف المشورة"
-            description={`هل تريد حذف المشورة: ${current.topic ?? ""}؟ لا يمكن التراجع عن هذه العملية.`}
-            confirmText="حذف"
-            cancelText="إلغاء"
-          />
-        )}
-      </Suspense>
     </div>
   );
 }

--- a/frontend/src/pages/LitigationDetailsPage.jsx
+++ b/frontend/src/pages/LitigationDetailsPage.jsx
@@ -1,74 +1,33 @@
-import { lazy, Suspense, useState, useContext } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { useLitigations } from "@/hooks/dataHooks";
-import { deleteLitigation } from "@/services/api/litigations";
-import { toast } from "sonner";
-import { AuthContext } from "@/context/AuthContext";
 
 const LitigationActionsTable = lazy(() =>
   import("@/components/Litigations/LitigationActionsTable")
-);
-const LitigationModal = lazy(() =>
-  import("@/components/Litigations/LitigationModal")
-);
-const GlobalConfirmDeleteModal = lazy(() =>
-  import("@/components/common/GlobalConfirmDeleteModal")
 );
 
 export default function LitigationDetailsPage() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
-  const { hasPermission } = useContext(AuthContext);
 
   const { data, refetch } = useLitigations();
   const litigations = data?.data?.data || [];
   const initialLitigation =
     location.state || litigations.find((l) => l.id === Number(id));
 
-  const [current, setCurrent] = useState(initialLitigation);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [current] = useState(initialLitigation);
 
   if (!current) {
     return <div className="p-4">لا توجد بيانات</div>;
   }
 
-  const reloadLitigation = async () => {
-    const res = await refetch();
-    const list = res?.data?.data || [];
-    const updated = list.find((l) => l.id === current.id);
-    if (updated) setCurrent(updated);
-  };
-
-  const handleDelete = async () => {
-    try {
-      await deleteLitigation(current.id);
-      toast.success("تم حذف الدعوى بنجاح");
-      await refetch();
-      navigate(-1);
-    } catch {
-      toast.error("فشل حذف الدعوى");
-    } finally {
-      setConfirmDelete(false);
-    }
-  };
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 min-h-screen">
       <div className="mb-4 flex gap-2">
         <Button onClick={() => navigate(-1)}>رجوع</Button>
-
-        {hasPermission(`edit litigation-${current.scope}`) && (
-          <Button onClick={() => setIsModalOpen(true)}>تعديل</Button>
-        )}
-
-        {hasPermission(`delete litigation-${current.scope}`) && (
-          <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            حذف
-          </Button>
-        )}
       </div>
 
       <div className="mb-6 p-4 bg-card text-fg rounded-xl shadow">
@@ -104,28 +63,6 @@ export default function LitigationDetailsPage() {
         />
       </Suspense>
 
-      <Suspense fallback={null}>
-        {isModalOpen && (
-          <LitigationModal
-            isOpen={isModalOpen}
-            onClose={() => setIsModalOpen(false)}
-            initialData={current}
-            reloadLitigations={reloadLitigation}
-          />
-        )}
-
-        {confirmDelete && (
-          <GlobalConfirmDeleteModal
-            isOpen={confirmDelete}
-            onClose={() => setConfirmDelete(false)}
-            onConfirm={handleDelete}
-            title="تأكيد حذف الدعوى"
-            description={`هل تريد حذف الدعوى رقم: ${current.case_number ?? ""}؟ لا يمكن التراجع عن هذه العملية.`}
-            confirmText="حذف"
-            cancelText="إلغاء"
-          />
-        )}
-      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide edit and delete buttons on Contract, LegalAdvice, Investigation, Litigation detail pages

## Testing
- `npm run lint`
- `npm test` *(fails: Jest encountered unexpected token and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5621043048328b6b159dcc38accd7