### PR TITLE
feat: unify modal styling across components

### DIFF
--- a/frontend/src/components/Users/UserModalForm.jsx
+++ b/frontend/src/components/Users/UserModalForm.jsx
@@ -3,6 +3,13 @@ import { toast } from 'sonner';
 import { User } from 'lucide-react';
 import API_CONFIG from '@/config/config';
 import { getRoles } from '@/services/api/users';
+import {
+  modalOverlay,
+  modalContainer,
+  modalInput,
+  modalCancelButton,
+  modalPrimaryButton,
+} from '@/components/common/modalStyles';
 
 const roleLabels = {
   admin: 'أدمن',
@@ -130,9 +137,9 @@ export default function UserModalForm({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6">
-      <div className="bg-white dark:bg-gray-900 w-full max-w-lg p-6 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 overflow-auto max-h-[90vh]">
-        <h2 className="text-xl font-bold text-center mb-6 text-gray-800 dark:text-white">
+    <div className={modalOverlay}>
+      <div className={`${modalContainer} max-w-lg`}>
+        <h2 className="text-xl font-bold text-center mb-6 text-fg">
           {isEdit ? 'تعديل المستخدم' : 'إضافة مستخدم'}
         </h2>
 
@@ -148,15 +155,13 @@ export default function UserModalForm({
           />
 
           <div>
-            <label className="block mb-1 font-medium text-gray-700 dark:text-gray-300">الدور</label>
+            <label className="block mb-1 font-medium text-fg">الدور</label>
             <select
               name="role"
               value={formData.role}
               onChange={handleChange}
               disabled={isSubmitting}
-              className={`w-full p-2 rounded border bg-white dark:bg-zinc-800 text-gray-900 dark:text-white ${
-                validationErrors.role ? 'border-red-500' : 'border-gray-300 dark:border-zinc-600'
-              }`}
+              className={`${modalInput} ${validationErrors.role ? 'border-red-500' : ''}`}
             >
               <option value="">اختر الدور</option>
               {availableRoles.map((r) => (
@@ -194,7 +199,7 @@ export default function UserModalForm({
               accept="image/*"
               disabled={isSubmitting}
               onChange={handleFileChange}
-              className="w-full rounded-xl bg-card border border-border text-fg placeholder:text-muted focus:ring-2 focus:ring-ring focus:border-border text-sm"
+              className={`${modalInput} text-sm`}
             />
             {formData.image && (
               <img
@@ -210,14 +215,14 @@ export default function UserModalForm({
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
-              className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-zinc-700 dark:hover:bg-zinc-600 text-gray-800 dark:text-white"
+              className={modalCancelButton}
             >
               إلغاء
             </button>
             <button
               type="submit"
               disabled={isSubmitting}
-              className="rounded-2xl px-4 py-2 bg-primary text-[color:var(--primary-foreground)] hover:shadow-glow transition"
+              className={modalPrimaryButton}
             >
               {isSubmitting ? '...جاري الحفظ' : isEdit ? 'تحديث' : 'إضافة'}
             </button>
@@ -239,9 +244,7 @@ function FormField({ label, icon, name, value, onChange, error, disabled }) {
         value={value}
         onChange={onChange}
         disabled={disabled}
-        className={`w-full rounded-xl bg-card border border-border text-fg placeholder:text-muted focus:ring-2 focus:ring-ring focus:border-border p-2 ${
-          error ? 'border-red-500' : ''
-        }`}
+        className={`${modalInput} ${error ? 'border-red-500' : ''}`}
       />
       {error && <p className="text-red-600 mt-1 text-xs">هذا الحقل مطلوب</p>}
     </div>

--- a/frontend/src/components/common/GlobalConfirmDeleteModal.jsx
+++ b/frontend/src/components/common/GlobalConfirmDeleteModal.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import {
+  modalOverlay,
+  modalContainer,
+  modalCancelButton,
+  modalDestructiveButton,
+} from './modalStyles';
 
 const GlobalConfirmDeleteModal = ({ isOpen, onClose, onConfirm, itemName }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-fg/20 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="p-6 rounded-lg shadow-lg max-w-md w-full bg-card">
+    <div className={modalOverlay}>
+      <div className={`${modalContainer} max-w-md`}>
         <h2 className="mb-4 text-center text-lg font-bold text-fg">
           تأكيد الحذف
         </h2>
@@ -14,16 +20,10 @@ const GlobalConfirmDeleteModal = ({ isOpen, onClose, onConfirm, itemName }) => {
           <span className="font-bold text-destructive">{itemName}</span>؟
         </p>
         <div className="flex justify-center gap-4">
-          <button
-            onClick={onConfirm}
-            className="px-4 py-2 rounded-2xl bg-destructive text-fg hover:brightness-110 hover:shadow-glow transition"
-          >
+          <button onClick={onConfirm} className={modalDestructiveButton}>
             تأكيد
           </button>
-          <button
-            onClick={onClose}
-            className="px-4 py-2 rounded-2xl bg-muted text-fg hover:shadow-glow transition"
-          >
+          <button onClick={onClose} className={modalCancelButton}>
             إلغاء
           </button>
         </div>

--- a/frontend/src/components/common/ModalCard.jsx
+++ b/frontend/src/components/common/ModalCard.jsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import {
+  modalOverlay,
+  modalContainer,
+  modalCancelButton,
+  modalPrimaryButton,
+} from './modalStyles';
 
 export default function ModalCard({
   isOpen,
@@ -13,10 +19,9 @@ export default function ModalCard({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+    <div className={modalOverlay}>
       <div
-        className={`relative w-full max-w-3xl max-h-[90vh] overflow-y-auto
-          card p-6 sm:p-8 flex flex-col
+        className={`${modalContainer} max-w-3xl sm:p-8 flex flex-col
           transition-all duration-300 ease-in-out
           hover:shadow-3xl hover:scale-[1.01]
           ${className}
@@ -49,7 +54,7 @@ export default function ModalCard({
           <button
             type="button"
             onClick={onClose}
-            className="px-5 py-2.5 rounded-2xl font-semibold bg-destructive text-fg hover:brightness-110 hover:shadow-glow transition-all duration-200"
+            className={`${modalCancelButton} font-semibold`}
           >
             إلغاء
           </button>
@@ -57,7 +62,7 @@ export default function ModalCard({
           <button
             onClick={onSubmit}
             disabled={loading}
-            className={`px-6 py-2.5 rounded-2xl font-bold bg-primary text-[color:var(--primary-foreground)] hover:shadow-glow disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200`}
+            className={`${modalPrimaryButton} px-6 py-2.5 font-bold disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             {loading ? '⏳ جاري الحفظ...' : submitLabel}
           </button>

--- a/frontend/src/components/common/modalStyles.js
+++ b/frontend/src/components/common/modalStyles.js
@@ -1,0 +1,7 @@
+export const modalOverlay = "fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-6";
+export const modalContainer = "bg-card w-full p-6 rounded-2xl shadow-xl border border-border overflow-auto max-h-[90vh]";
+export const modalInput = "w-full rounded-xl bg-card border border-border text-fg placeholder:text-muted focus:ring-2 focus:ring-ring focus:border-border p-2";
+const buttonBase = "px-4 py-2 rounded-2xl hover:shadow-glow transition";
+export const modalCancelButton = `${buttonBase} bg-muted text-fg`;
+export const modalPrimaryButton = `${buttonBase} bg-primary text-[color:var(--primary-foreground)]`;
+export const modalDestructiveButton = `${buttonBase} bg-destructive text-fg hover:brightness-110`;


### PR DESCRIPTION
## Summary
- centralize modal overlay, container, input, and button classes
- refactor user and confirm delete modals to use shared styles
- align reusable ModalCard with global modal constants

## Testing
- `npm test` (fails: jest: not found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b56e950ec88328a11c06367fe0db40