### PR TITLE
feat: localize login and language toggle

### DIFF
--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -12,7 +12,7 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
   const { login } = useContext(AuthContext);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { lang } = useLanguage();
+  const { t } = useLanguage();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -22,18 +22,18 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
       const { success, message } = await login(email, password);
 
       if (success) {
-        toast.success('✅ تم تسجيل الدخول بنجاح', { description: 'تم الدخول إلى النظام بنجاح.' });
+        toast.success(t('loginSuccessTitle'), { description: t('loginSuccessMessage') });
         onAuthComplete(true);
       } else {
         const errorMsg = message === 'Bad credentials'
-          ? 'تأكد من صحة اسم المستخدم وكلمة المرور.'
+          ? t('loginFailedBadCredentials')
           : message;
 
-        toast.error('❌ فشل تسجيل الدخول', { description: errorMsg });
+        toast.error(t('loginFailedTitle'), { description: errorMsg });
         onAuthComplete(false);
       }
     } catch (error) {
-      toast.error('حدث خطأ غير متوقع', { description: error.message });
+      toast.error(t('unexpectedError'), { description: error.message });
       onAuthComplete(false);
     }
   };
@@ -61,7 +61,7 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
           id="login-title"
           className="text-center text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 via-lime-300 to-emerald-500 drop-shadow-xl"
         >
-          {lang === 'ar' ? 'تسجيل الدخول' : 'Sign In'}
+          {t('signIn')}
         </h2>
 
         <form onSubmit={handleSubmit} className="space-y-5">
@@ -70,8 +70,8 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
             name="email"
             value={email}
             onChange={e => setEmail(e.target.value)}
-            placeholder={{ ar: 'البريد الإلكتروني', en: 'Email' }}
-            label={{ ar: 'البريد الإلكتروني', en: 'Email' }}
+            placeholder={t('email')}
+            label={t('email')}
           />
 
           <FormField
@@ -79,15 +79,15 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
             name="password"
             value={password}
             onChange={e => setPassword(e.target.value)}
-            placeholder={{ ar: 'كلمة المرور', en: 'Password' }}
-            label={{ ar: 'كلمة المرور', en: 'Password' }}
+            placeholder={t('password')}
+            label={t('password')}
           />
 
           <Button
             type="submit"
             className="w-full py-3 font-bold text-white bg-gradient-to-l from-emerald-600 via-green-600 to-emerald-700 rounded-lg shadow-md hover:scale-105 transition-all"
           >
-            {lang === 'ar' ? '🚀 دخول' : '🚀 Login'}
+            {`🚀 ${t('signIn')}`}
           </Button>
 
           <button
@@ -95,7 +95,7 @@ const Login = ({ onAuthStart, onAuthComplete, handleFormClose }) => {
             onClick={handleCancel}
             className="w-full py-3 font-semibold text-white bg-gray-600/80 border border-gray-500 rounded-lg hover:bg-gray-500 transition-all hover:scale-105"
           >
-            {lang === 'ar' ? 'إلغاء' : 'Cancel'}
+            {t('cancel')}
           </button>
         </form>
       </div>

--- a/frontend/src/components/common/LanguageToggle.jsx
+++ b/frontend/src/components/common/LanguageToggle.jsx
@@ -3,13 +3,13 @@ import { useLanguage } from '@/context/LanguageContext';
 import { Button } from '@/components/ui/button';
 
 export default function LanguageToggle() {
-  const { lang, toggleLanguage } = useLanguage();
+  const { lang, toggleLanguage, t } = useLanguage();
   return (
     <Button
       variant="ghost"
       size="icon"
       onClick={toggleLanguage}
-      aria-label={lang === 'ar' ? 'Switch to English' : 'التبديل إلى العربية'}
+      aria-label={lang === 'ar' ? t('switchToEnglish') : t('switchToArabic')}
     >
       {lang === 'ar' ? 'EN' : 'ع'}
     </Button>

--- a/frontend/src/context/LanguageContext.jsx
+++ b/frontend/src/context/LanguageContext.jsx
@@ -119,7 +119,14 @@ const translations = {
     profile: "الملف الشخصي",
     language: "اللغة",
     arabic: "العربية",
-    english: "الإنجليزية"
+    english: "الإنجليزية",
+    loginSuccessTitle: "تم تسجيل الدخول بنجاح",
+    loginSuccessMessage: "تم الدخول إلى النظام بنجاح.",
+    loginFailedTitle: "فشل تسجيل الدخول",
+    loginFailedBadCredentials: "تأكد من صحة اسم المستخدم وكلمة المرور.",
+    unexpectedError: "حدث خطأ غير متوقع",
+    switchToEnglish: "التبديل إلى الإنجليزية",
+    switchToArabic: "التبديل إلى العربية"
   },
   en: {
     home: 'Home',
@@ -234,7 +241,14 @@ const translations = {
     profile: "Profile",
     language: "Language",
     arabic: "Arabic",
-    english: "English"
+    english: "English",
+    loginSuccessTitle: "Login Successful",
+    loginSuccessMessage: "Logged into the system successfully.",
+    loginFailedTitle: "Login Failed",
+    loginFailedBadCredentials: "Please check your username and password.",
+    unexpectedError: "An unexpected error occurred",
+    switchToEnglish: "Switch to English",
+    switchToArabic: "Switch to Arabic"
   }
 };
 


### PR DESCRIPTION
## Summary
- centralize login form labels, placeholders, and messages using translation helper
- expose translation entries for login and language toggle
- localize language toggle aria-labels

## Testing
- `npm run lint`
- `npm test` *(fails: Geo check failed / fetch not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b572b99484832898ec3ea7e3c25f78