### PR TITLE
feat: add IconMedallion for section headers and update editor label

### DIFF
--- a/frontend/src/components/common/IconMedallion.jsx
+++ b/frontend/src/components/common/IconMedallion.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+function IconMedallion({ children, size = "md", spin = false }) {
+  const sizes = {
+    sm: "w-14 h-14 sm:w-16 sm:h-16",
+    md: "w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24",
+    lg: "w-24 h-24 sm:w-28 sm:h-28",
+  };
+
+  return (
+    <div className={`relative ${sizes[size]} select-none`}>
+      {/* حلقة خارجية متدرجة (برواز) */}
+      <div
+        className={`absolute inset-0 rounded-full ${spin ? "animate-[spin_8s_linear_infinite]" : ""}`}
+        style={{
+          background:
+            "conic-gradient(from 0deg, var(--primary), var(--accent), var(--secondary), var(--primary))",
+          boxShadow:
+            "0 2px 8px rgba(0,0,0,.10), 0 6px 18px rgba(0,0,0,.08)",
+        }}
+        aria-hidden
+      />
+
+      {/* جسم البرواز (خلفية داخلية + بَفْل/مجسّم) */}
+      <div
+        className="relative grid place-items-center w-full h-full rounded-full bg-[var(--card)]"
+        style={{
+          // طبقات ظل داخلية تعطي إحساس حافة معدنية
+          boxShadow:
+            "inset 0 10px 18px rgba(255,255,255,0.28), inset 0 -10px 18px rgba(0,0,0,0.08), 0 0 0 1px var(--border)",
+        }}
+      >
+        {/* لمعان علوي نصف شفاف */}
+        <div
+          className="absolute inset-0 rounded-full pointer-events-none"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.22), rgba(255,255,255,0) 38%)",
+            mixBlendMode: "screen",
+          }}
+          aria-hidden
+        />
+
+        {/* محتوى الأيقونة */}
+        <div
+          className="relative rounded-full grid place-items-center"
+          style={{
+            width: "70%",
+            height: "70%",
+            background:
+              "radial-gradient(50% 50% at 50% 35%, rgba(255,255,255,0.35), rgba(255,255,255,0) 60%)",
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default IconMedallion;
+

--- a/frontend/src/components/common/SectionHeader.jsx
+++ b/frontend/src/components/common/SectionHeader.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from "react";
 import { ArrowLeft } from "lucide-react";
+import IconMedallion from "./IconMedallion";
 
 /**
  * Props:
@@ -130,28 +131,20 @@ const SectionHeader = ({
       >
         {/* أيقونة */}
         {icon && (
-          <div
-            className="
-              grid place-items-center w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24
-              rounded-2xl border border-[var(--border)]
-              shadow-[var(--shadow-sm)]
-              transition-transform duration-300 group-hover:scale-[1.03]
-              bg-[var(--card)]
-            "
-            style={{
-              boxShadow: "var(--shadow-glow)",
-            }}
-          >
+          <IconMedallion size="md" spin={true}>
             {typeof icon === "string" ? (
               <img
                 src={icon}
                 alt={typeof listName === "string" ? listName : "section icon"}
-                className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 object-contain"
+                className="w-10 h-10 sm:w-12 sm:h-12 object-contain"
               />
             ) : (
-              icon
+              // لو الأيقونة ReactNode (SVG)
+              <div className="w-8 h-8 sm:w-10 sm:h-10 text-[var(--fg)]">
+                {icon}
+              </div>
             )}
-          </div>
+          </IconMedallion>
         )}
 
         {/* العنوان + أكشنات */}

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -9,7 +9,7 @@
   "usersManagement": "إدارة المستخدمين",
   "usersList": "المستخدمين",
   "archive": "الأرشيف",
-  "documentEditor": "محرر المستندات",
+  "documentEditor": "محرر ملفات Word",
   "fatwa": "الرأي والفتوى",
   "title": "لوحة التحكم الرئيسية",
   "subtitle": "نظام متقدم لإدارة ومتابعة القضايا القانونية",


### PR DESCRIPTION
## Summary
- wrap section header icons with new IconMedallion component
- rename Arabic document editor label to "محرر ملفات Word"

## Testing
- `npm test` *(fails: Geo check failed; SyntaxError: Unexpected token 'export')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6422117b8832890fc2e40494cd51b