### PR TITLE
feat: add document editor route and sidebar link

### DIFF
--- a/frontend/src/components/layout/AppSidebar.jsx
+++ b/frontend/src/components/layout/AppSidebar.jsx
@@ -56,6 +56,7 @@ export default function AppSidebar({ isOpen, onToggle, onLinkClick }) {
 
   const navConfig = useMemo(() => [
     { id: 'home', label: t('home'), to: '/', icon: <DashboardIcon size={20} /> },
+    { id: 'editor', label: t('editor'), to: '/editor', icon: <FileText size={20} /> },
     hasPermission('view contracts') && {
       id: 'contracts', label: t('contracts'), to: '/contracts', icon: <ContractsIcon size={20} />
     },

--- a/frontend/src/components/layout/AuthRoutes.jsx
+++ b/frontend/src/components/layout/AuthRoutes.jsx
@@ -5,7 +5,7 @@ import GlobalSpinner from '../common/Spinners/GlobalSpinner';
 import { lazy } from 'react';
 import Forbidden from '@/pages/Forbidden';
 import ProtectedRoute from '@/components/templates/ProtectedRoute.jsx';
-import ProfilePage from '../../pages/ProfilePage.jsx'; 
+import ProfilePage from '../../pages/ProfilePage.jsx';
 
 const Home = lazy(() => import('../../pages/Dashboard.jsx'));
 const Contracts = lazy(() => import('../../pages/ContractsPage.jsx'));
@@ -20,6 +20,7 @@ const UserManagementPage = lazy(() => import('../../pages/UserManagementPage.jsx
 const ArchivePage = lazy(() => import('../../pages/ArchivePage.jsx'));
 const ManagementSettings = lazy(() => import('../../pages/ManagementSettings.jsx'));
 const ReportsPage = lazy(() => import('../../pages/ReportsPage.jsx'));
+const DocumentEditor = lazy(() => import('@/components/editor/DocumentEditor'));
 const NotFound = () => <h1 className="text-center text-red-500">404 - Page Not Found</h1>;
 
 const AuthRoutes = () => {
@@ -42,6 +43,7 @@ const AuthRoutes = () => {
           <Route path="/" element={<Home />} />
           <Route path="/profile/:userId" element={<ProfilePage />} />
           <Route path="/archive" element={<ArchivePage />} />
+          <Route path="/editor" element={<DocumentEditor />} />
           <Route path="/contracts" element={<ProtectedRoute permission="view contracts"><Contracts /></ProtectedRoute>} />
           <Route path="/contracts/:id" element={<ProtectedRoute permission="view contracts"><ContractDetailsPage /></ProtectedRoute>} />
           <Route path="/profile" element={<ProtectedRoute permission="view profile"><ProfilePage /></ProtectedRoute>} />

--- a/frontend/src/locales/ar.json
+++ b/frontend/src/locales/ar.json
@@ -1,5 +1,6 @@
 {
   "home": "الرئيسية",
+  "editor": "المحرر",
   "investigations": "التحقيقات",
   "legalAdvices": "المشورة القانونية",
   "litigations": "التقاضي",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "home": "Home",
+  "editor": "Editor",
   "dashboard": "Dashboard",
   "contracts": "Contracts",
   "investigations": "Investigations",


### PR DESCRIPTION
## Summary
- add document editor link to sidebar
- register /editor route in authenticated routes
- localize sidebar label

## Testing
- `npm test` *(fails: ReferenceError: React is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b770ce59248328a9ed1d996f9af05f